### PR TITLE
refactor: RelationConfigコメントアウト削除と技術的負債の解消

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -81,18 +81,6 @@ function AppContent() {
                     // キャンセル時の処理 (必要に応じて実装)
                   }}
                 />;
-      // case AppPhaseConstants.relation:
-      //   return  <RelationConfig 
-      //             students={students}
-      //             currentRelationConfig={relationConfig}
-      //             onConfigFinished={(updateRelationConfig: RelationConfigData[]) => {
-      //               setRelationConfig(updateRelationConfig);
-      //               setAppPhase(AppPhaseConstants.roulette); // 関係性設定後はルーレットフェーズへ進む
-      //             }}
-      //             onCancel={() => {
-      //               // キャンセル時の処理 (必要に応じて実装)
-      //             }}
-      //           />;
       case AppPhaseConstants.roulette:
         return  <RouletteDisplay />;
       case AppPhaseConstants.chart:

--- a/src/components/Config/FixedSeatConfig.tsx
+++ b/src/components/Config/FixedSeatConfig.tsx
@@ -7,6 +7,7 @@ import {
   Grid,
   List,
   ListItem,
+  ListItemButton,
   ListItemText,
   ListItemIcon,
   Avatar,
@@ -236,8 +237,7 @@ const FixedSeatConfig: React.FC<FixedSeatConfigProps> = ({
 
       <Grid container spacing={4}>
         {/* 左側: 生徒リスト */}
-        {/* @ts-ignore */}
-        <Grid item xs={12} md={6} size={4}>
+        <Grid size={{ xs: 12, md: 6 }}>
           <Paper elevation={2} sx={{ p: 2, height: '100%' }}>
             <Typography variant="h6" gutterBottom>
               生徒の選択
@@ -250,13 +250,11 @@ const FixedSeatConfig: React.FC<FixedSeatConfigProps> = ({
                 <ListItem><ListItemText secondary="生徒がいません。最初のステップで生徒を登録してください。" /></ListItem>
               ) : (
                 sortedStudents.map((student) => (
-                  // @ts-ignore
-                  <ListItem
+                  <ListItemButton
                     key={student.id}
-                    button
                     onClick={() => handleStudentClick(student.id)}
                     selected={selectedStudentId === student.id}
-                    disabled={assignedStudentIds.has(student.id)} // 既に割り当てられている生徒は選択不可
+                    disabled={assignedStudentIds.has(student.id)}
                     sx={{
                       '&.Mui-selected': {
                         backgroundColor: (theme) => theme.palette.primary.light + ' !important',
@@ -270,7 +268,7 @@ const FixedSeatConfig: React.FC<FixedSeatConfigProps> = ({
                       <Avatar>{student.number}</Avatar>
                     </ListItemIcon>
                     <ListItemText primary={`${student.name}`} />
-                  </ListItem>
+                  </ListItemButton>
                 ))
               )}
             </List>
@@ -278,8 +276,7 @@ const FixedSeatConfig: React.FC<FixedSeatConfigProps> = ({
         </Grid>
 
         {/* 右側: 座席グリッド (SeatMapChart を使用) */}
-        {/* @ts-ignore */}
-        <Grid item xs={12} md={6} size={8}>
+        <Grid size={{ xs: 12, md: 6 }}>
           <Paper elevation={2} sx={{ p: 2, height: '100%' }}>
             <Typography variant="h6" gutterBottom>
               座席の選択

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -1,6 +1,6 @@
 // src/Layout/Layout.tsx
 import React, { useState, useCallback } from "react";
-import { AppBar, Toolbar, Typography, Container, Box, Button, ButtonGroup, Tooltip, IconButton, Menu, MenuItem } from "@mui/material";
+import { AppBar, Toolbar, Typography, Container, Box, Button, ButtonGroup, Tooltip, IconButton, Menu, MenuItem, Snackbar, Alert } from "@mui/material";
 import { saveAppData, loadAppData, clearAppData } from "../../utils/localStorage";
 import type { AppPersistedState } from "../../utils/localStorage";
 import MoreVertIcon from '@mui/icons-material/MoreVert'; // メニューアイコン
@@ -32,9 +32,13 @@ const Layout: React.FC<LayoutProps> = ({children}) => {
     setFixedSeatAssignments,
   } = useAppState();
 
-  // メニューの状態管理
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
+  const [snackbar, setSnackbar] = useState<{ open: boolean; message: string; severity: 'success' | 'error' | 'warning' | 'info' }>({ open: false, message: '', severity: 'info' });
+
+  const showSnackbar = useCallback((message: string, severity: 'success' | 'error' | 'warning' | 'info') => {
+    setSnackbar({ open: true, message, severity });
+  }, []);
 
   const handleClickMenu = (event: React.MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(event.currentTarget);
@@ -44,7 +48,6 @@ const Layout: React.FC<LayoutProps> = ({children}) => {
     setAnchorEl(null);
   };
 
-  // 全データをLocalStorageに保存するハンドラ
   const handleSaveData = useCallback(() => {
     try {
       const dataToSave: AppPersistedState = {
@@ -53,48 +56,45 @@ const Layout: React.FC<LayoutProps> = ({children}) => {
         appPhase,
         rouletteState,
         relationConfig,
-        fixedSeatAssignments, // 新しい固定座席割り当てを保存
+        fixedSeatAssignments,
       };
-      saveAppData(dataToSave); // LocalStorageにデータを保存
-      alert('データを保存しました！');
+      saveAppData(dataToSave);
+      showSnackbar('データを保存しました！', 'success');
     } catch (error) {
       console.error('データの保存中にエラーが発生しました:', error);
-      alert('データの保存に失敗しました。');
+      showSnackbar('データの保存に失敗しました。', 'error');
     } finally {
-      handleCloseMenu(); // メニューを閉じる
+      handleCloseMenu();
     }
-  }, [students, seatMap, appPhase, rouletteState, relationConfig]);
+  }, [students, seatMap, appPhase, rouletteState, relationConfig, fixedSeatAssignments, showSnackbar]);
 
-  // LocalStorageからデータを読み込むハンドラ
   const handleLoadData = useCallback(() => {
-    handleCloseMenu(); // メニューを閉じる
+    handleCloseMenu();
     if (!window.confirm('現在のデータは失われますが、データを読み込みますか？')) {
       return;
     }
     try {
-      const loadedData = loadAppData(); // ヘルパー関数を呼び出す
+      const loadedData = loadAppData();
       if (loadedData) {
         setStudents(loadedData.students);
         setSeatMap(loadedData.seatMap);
         setAppPhase(loadedData.appPhase);
         setRouletteState(loadedData.rouletteState);
         setRelationConfig(loadedData.relationConfig);
-        setFixedSeatAssignments(loadedData.fixedSeatAssignments); // 新しい固定座席割り当てをセット
-        alert('データを読み込みました！');
+        setFixedSeatAssignments(loadedData.fixedSeatAssignments);
+        showSnackbar('データを読み込みました！', 'success');
       } else {
-        alert('保存されたデータがありません。');
+        showSnackbar('保存されたデータがありません。', 'info');
       }
     } catch (error) {
-      // loadAppData 内でエラーは捕捉されるが、必要ならここでも処理
-      alert('データの読み込みに失敗しました。データ形式が不正な可能性があります。');
+      showSnackbar('データの読み込みに失敗しました。データ形式が不正な可能性があります。', 'error');
     }
-  }, [setStudents, setSeatMap, setAppPhase, setRouletteState, setRelationConfig]);
+  }, [setStudents, setSeatMap, setAppPhase, setRouletteState, setRelationConfig, setFixedSeatAssignments, showSnackbar]);
 
-  // 全データをリセットするハンドラ
   const handleResetData = useCallback(() => {
-    handleCloseMenu(); // メニューを閉じる
+    handleCloseMenu();
     try {
-      clearAppData(); // ヘルパー関数を呼び出す
+      clearAppData();
       setStudents([]);
       setSeatMap([]);
       setAppPhase('input');
@@ -106,20 +106,18 @@ const Layout: React.FC<LayoutProps> = ({children}) => {
         isStopped: false,
       });
       setRelationConfig([]);
-      setFixedSeatAssignments([]); // 新しい固定座席割り当てをリセット
-      alert('全てのデータがリセットされました。');
+      setFixedSeatAssignments([]);
+      showSnackbar('全てのデータがリセットされました。', 'success');
     } catch (error) {
-      // clearAppData 内でエラーは捕捉されるが、必要ならここでも処理
-      alert('データのリセットに失敗しました。');
+      showSnackbar('データのリセットに失敗しました。', 'error');
     }
-  }, [setStudents, setSeatMap, setAppPhase, setRouletteState, setRelationConfig]);
+  }, [setStudents, setSeatMap, setAppPhase, setRouletteState, setRelationConfig, setFixedSeatAssignments, showSnackbar]);
 
 
   const appPhases: AppPhase[] = [
     "input",
     "config",
     "fixedSeat",
-    // "relation",
     "roulette",
     "chart",
     "finished",
@@ -200,6 +198,17 @@ const Layout: React.FC<LayoutProps> = ({children}) => {
           {children}
         </Box>
       </Container>
+
+      <Snackbar
+        open={snackbar.open}
+        autoHideDuration={4000}
+        onClose={() => setSnackbar(prev => ({ ...prev, open: false }))}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert severity={snackbar.severity} onClose={() => setSnackbar(prev => ({ ...prev, open: false }))}>
+          {snackbar.message}
+        </Alert>
+      </Snackbar>
     </Box>
   );
 }

--- a/src/components/Output/OutputPanel.tsx
+++ b/src/components/Output/OutputPanel.tsx
@@ -9,6 +9,8 @@ import {
   Typography,
   Grid,
   Tooltip,
+  Snackbar,
+  Alert,
 } from '@mui/material';
 import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
@@ -35,7 +37,6 @@ interface StudentOutputFields {
 const OutputPanel: React.FC = () => {
   const { students, seatMap } = useAppState();
 
-  // チェックボックスの状態管理
   const [selectedFields, setSelectedFields] = useState<StudentOutputFields>({
     id: false,
     number: true, // デフォルトで出席番号を表示
@@ -45,8 +46,12 @@ const OutputPanel: React.FC = () => {
     info2: false,
     info3: false,
   });
+  const [snackbar, setSnackbar] = useState<{ open: boolean; message: string; severity: 'success' | 'error' | 'warning' | 'info' }>({ open: false, message: '', severity: 'info' });
 
-  // チェックボックスの変更ハンドラ
+  const showSnackbar = useCallback((message: string, severity: 'success' | 'error' | 'warning' | 'info') => {
+    setSnackbar({ open: true, message, severity });
+  }, []);
+
   const handleFieldChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
       setSelectedFields({
@@ -99,55 +104,46 @@ const OutputPanel: React.FC = () => {
     return tableData;
   }, [students, seatMap, selectedFields]);
 
-  // PDF出力ハンドラ
   const handleGeneratePdf = useCallback(async () => {
     if (!hasSelectedFields) {
-      // NOTE: alert() は UI をブロックするため、本番環境ではカスタムモーダルなどに置き換えるべきです。
-      alert('表示したい項目を選択してください。');
+      showSnackbar('表示したい項目を選択してください。', 'warning');
       return;
     }
 
-    // main-seating-chart-container の内容をPDF化します。
-    // このdivには、SeatMapChartと詳細データテーブルの両方が含まれます。
     const input = document.getElementById('main-seating-chart-container');
-
     if (!input) {
-      // NOTE: alert() は UI をブロックするため、本番環境ではカスタムモーダルなどに置き換えるべきです。
-      alert('PDF出力元の要素が見つかりません。開発者ツールでIDを確認してください。');
+      showSnackbar('PDF出力元の要素が見つかりません。', 'error');
       return;
     }
 
     try {
       const canvas = await html2canvas(input, {
-        scale: 2, // 高解像度でキャプチャ
-        useCORS: true, // 外部画像などがある場合にCORSを許可
-        logging: true, // デバッグ用にログを出力
+        scale: 2,
+        useCORS: true,
+        logging: true,
       });
       const imgData = canvas.toDataURL('image/jpeg');
       const pdf = new jsPDF({
-        orientation: 'landscape', // 横向き
+        orientation: 'landscape',
         unit: 'mm',
         format: 'a4',
       });
 
-      const imgWidth = 297; // A4横の幅
+      const imgWidth = 297;
       const imgHeight = (canvas.height * imgWidth) / canvas.width;
       const margin = 10;
       pdf.addImage(imgData, 'PNG', margin, margin, imgWidth - 2 * margin, imgHeight - 2 * margin);
       pdf.save('seat-arrangement-chart.pdf');
     } catch (error) {
       console.error('PDF生成中にエラーが発生しました:', error);
-      // NOTE: alert() は UI をブロックするため、本番環境ではカスタムモーダルなどに置き換えるべきです。
-      alert('PDFの生成に失敗しました。');
+      showSnackbar('PDFの生成に失敗しました。', 'error');
     }
-  }, [hasSelectedFields]);
+  }, [hasSelectedFields, showSnackbar]);
 
 
-  // クリップボードにコピーするハンドラ (CSV形式)
-  const handleCopyToClipboard = useCallback(() => {
+  const handleCopyToClipboard = useCallback(async () => {
     if (!hasSelectedFields) {
-      // NOTE: alert() は UI をブロックするため、本番環境ではカスタムモーダルなどに置き換えるべきです。
-      alert('表示したい項目を選択してください。');
+      showSnackbar('表示したい項目を選択してください。', 'warning');
       return;
     }
 
@@ -155,7 +151,6 @@ const OutputPanel: React.FC = () => {
     const maxCol = Math.max(...seatMap.map((seat) => seat.col));
     let csvContent = '';
 
-    // 選択されたフィールドのキーのリストと、そのラベルのマップ
     const activeFieldKeys: { key: keyof StudentOutputFields; label: string }[] = [];
     if (selectedFields.id) activeFieldKeys.push({ key: 'id', label: '生徒ID' });
     if (selectedFields.number) activeFieldKeys.push({ key: 'number', label: '出席番号' });
@@ -165,13 +160,9 @@ const OutputPanel: React.FC = () => {
     if (selectedFields.info2) activeFieldKeys.push({ key: 'info2', label: '情報2' });
     if (selectedFields.info3) activeFieldKeys.push({ key: 'info3', label: '情報3' });
 
-    // 各座席表の行に対応するCSVブロックを生成
     for (let r = 1; r <= maxRow; r++) {
-
-      // 各項目ごとのデータ行を生成 (例: 出席番号	S1_番号	S2_番号)
       activeFieldKeys.forEach(field => {
-        let fieldDataRow: (string | number | null)[] = [];
-        fieldDataRow.push(field.label); // 項目名（例: 出席番号）
+        const fieldDataRow: (string | number | null)[] = [field.label];
 
         for (let c = 1; c <= maxCol; c++) {
           const seat = seatMap.find((s) => s.row === r && s.col === c && s.isUsable);
@@ -179,14 +170,14 @@ const OutputPanel: React.FC = () => {
             ? students.find((s) => s.id === seat.assignedStudentId)
             : null;
 
-          if (seat) { // 使用可能な座席
-            if (student) { // 生徒が割り当てられている場合
-              // @ts-ignore
-              fieldDataRow.push(student[field.key] ?? ''); // 該当フィールドの値
-            } else { // 空席の場合
+          if (seat) {
+            if (student) {
+              const value = student[field.key as 'id' | 'number' | 'name' | 'kana' | 'info1' | 'info2' | 'info3'];
+              fieldDataRow.push(value ?? '');
+            } else {
               fieldDataRow.push('空席');
             }
-          } else { // 使用不可な座席
+          } else {
             fieldDataRow.push('使用不可');
           }
         }
@@ -194,32 +185,14 @@ const OutputPanel: React.FC = () => {
       });
     }
 
-    // document.execCommand('copy') を使用してクリップボードにコピー
-    const textarea = document.createElement('textarea');
-    textarea.value = csvContent;
-    textarea.style.position = 'fixed'; // 画面外に配置
-    textarea.style.left = '-9999px';
-    document.body.appendChild(textarea);
-    textarea.focus();
-    textarea.select();
     try {
-      const successful = document.execCommand('copy');
-      if (successful) {
-        // NOTE: alert() は UI をブロックするため、本番環境ではカスタムモーダルなどに置き換えるべきです。
-        alert('座席データがクリップボードにコピーされました！\n表計算ソフトに貼り付けてください。');
-      } else {
-        console.error('Fallback: クリップボードへのコピーに失敗しました (execCommand)');
-        // NOTE: alert() は UI をブロックするため、本番環境ではカスタムモーダルなどに置き換えるべきです。
-        alert('クリップボードへのコピーに失敗しました。ブラウザがこの操作を許可していません。');
-      }
+      await navigator.clipboard.writeText(csvContent);
+      showSnackbar('座席データがクリップボードにコピーされました！表計算ソフトに貼り付けてください。', 'success');
     } catch (err) {
-      console.error('Fallback: クリップボードへのコピー中にエラーが発生しました:', err);
-      // NOTE: alert() は UI をブロックするため、本番環境ではカスタムモーダルなどに置き換えるべきです。
-      alert('クリップボードへのコピーに失敗しました。');
-    } finally {
-      document.body.removeChild(textarea); // 一時的なtextareaを削除
+      console.error('クリップボードへのコピーに失敗しました:', err);
+      showSnackbar('クリップボードへのコピーに失敗しました。', 'error');
     }
-  }, [hasSelectedFields, getOutputTableData, selectedFields]);
+  }, [hasSelectedFields, seatMap, students, selectedFields, showSnackbar]);
 
   return (
     <>
@@ -232,8 +205,7 @@ const OutputPanel: React.FC = () => {
         <Typography variant="subtitle1" sx={{ mb: 1 }}>表示項目を選択:</Typography>
         <Grid container spacing={1}>
           {Object.entries(selectedFields).map(([key, value]) => (
-            // @ts-ignore
-            <Grid item xs={4} sm={2} key={key}>
+            <Grid size={{ xs: 4, sm: 2 }} key={key}>
               <FormControlLabel
                 control={
                   <Checkbox
@@ -247,7 +219,7 @@ const OutputPanel: React.FC = () => {
                   key === 'number' ? '出席番号' :
                   key === 'name' ? '名前' :
                   key === 'kana' ? 'フリガナ' :
-                  `情報${key.slice(-1)}` // info1, info2, info3
+                  `情報${key.slice(-1)}`
                 }
               />
             </Grid>
@@ -350,6 +322,17 @@ const OutputPanel: React.FC = () => {
           </Typography>
         )}
       </Paper>
+
+      <Snackbar
+        open={snackbar.open}
+        autoHideDuration={4000}
+        onClose={() => setSnackbar(prev => ({ ...prev, open: false }))}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert severity={snackbar.severity} onClose={() => setSnackbar(prev => ({ ...prev, open: false }))}>
+          {snackbar.message}
+        </Alert>
+      </Snackbar>
     </>
   );
 };

--- a/src/components/Roulette/RouletteDisplay.tsx
+++ b/src/components/Roulette/RouletteDisplay.tsx
@@ -84,7 +84,6 @@ const RouletteDisplay: React.FC = () => {
     setAppPhase,
   } = useAppState();
 
-  const rouletteIntervalRef = useRef<NodeJS.Timeout | null>(null);
   const animationFrameRef = useRef<number | null>(null);
   const rouletteSpeed = 60;
   const [openResultModal, setOpenResultModal] = useState<boolean>(false);
@@ -171,10 +170,6 @@ const RouletteDisplay: React.FC = () => {
     if (animationFrameRef.current) {
       cancelAnimationFrame(animationFrameRef.current);
     }
-    if (rouletteIntervalRef.current) {
-        clearInterval(rouletteIntervalRef.current);
-        rouletteIntervalRef.current = null;
-    }
 
     let lastTime = 0;
     const animate = (currentTime: number) => {
@@ -190,21 +185,12 @@ const RouletteDisplay: React.FC = () => {
       animationFrameRef.current = requestAnimationFrame(animate);
     };
     animationFrameRef.current = requestAnimationFrame(animate);
-
-    rouletteIntervalRef.current = setInterval(() => {
-        // ここでは特に何もしない
-    }, 1000);
   }, [availableSeats, rouletteState.isRunning, selectedStudentForAssignment, setRouletteState, rouletteSpeed]);
 
 
   // ルーレット停止ハンドラ
   const stopRoulette = useCallback(() => {
     if (!rouletteState.isRunning) return;
-
-    if (rouletteIntervalRef.current) {
-      clearInterval(rouletteIntervalRef.current);
-      rouletteIntervalRef.current = null;
-    }
 
     if (animationFrameRef.current) {
       cancelAnimationFrame(animationFrameRef.current);
@@ -597,8 +583,7 @@ const RouletteDisplay: React.FC = () => {
 
       <Grid container spacing={4}>
         {/* 左側: 未割り当て生徒リスト */}
-        {/* @ts-ignore */}
-        <Grid item xs={12} md={4} size={3}>
+        <Grid size={{ xs: 12, md: 4 }}>
           <Paper elevation={2} sx={{ p: 2, height: '100%' }}>
             <StudentList
               title={`未割り当て生徒 (${unassignedStudents.length}人)`}
@@ -664,8 +649,7 @@ const RouletteDisplay: React.FC = () => {
         </Grid>
 
         {/* 右側: 座席レイアウト表示エリア */}
-        {/* @ts-ignore */}
-        <Grid item xs={12} md={8} size={9}>
+        <Grid size={{ xs: 12, md: 8 }}>
           <Paper elevation={2} sx={{ p: 2, overflowX: 'auto' }}>
             <Typography variant="h6" gutterBottom>
               座席レイアウト
@@ -677,8 +661,7 @@ const RouletteDisplay: React.FC = () => {
               {seatMap.length > 0 && Array.from({
                 length: Math.max(...seatMap.map(s => parseInt(s.seatId.match(/R(\d+)C(\d+)/)?.[1] || '0', 10)))
               }).map((_, rowIndex) => (
-                // @ts-ignore
-                <Grid container item xs={12} key={`row-${rowIndex}`} spacing={1} justifyContent="center" wrap="no-wrap">
+                <Grid container size={12} key={`row-${rowIndex}`} spacing={1} justifyContent="center" wrap="nowrap">
                   {Array.from({
                     length: Math.max(...seatMap.map(s => parseInt(s.seatId.match(/R(\d+)C(\d+)/)?.[2] || '0', 10)))
                   }).map((_, colIndex) => {
@@ -690,13 +673,11 @@ const RouletteDisplay: React.FC = () => {
                     const assignedStudent = students.find(s => s.id === seatData.assignedStudentId);
 
                     const isHighlighted = rouletteState.isRunning && rouletteState.currentSelectedSeatId === seatId;
-                    // 手動選択された座席もハイライト
                     const isManuallySelected = manuallySelectedSeatIdForRoulette === seatId;
                     const highlightColor = isHighlighted || isManuallySelected ? 'warning.main' : undefined;
 
                     return (
-                      // @ts-ignore
-                      <Grid item key={seatId}>
+                      <Grid key={seatId}>
                         <Box sx={{
                             border: (isHighlighted || isManuallySelected) ? '3px solid' : '1px solid',
                             borderColor: (isHighlighted || isManuallySelected) ? highlightColor : (assignedStudent ? 'primary.dark' : 'grey.400'),

--- a/src/components/Seat/SeatMapConfig.tsx
+++ b/src/components/Seat/SeatMapConfig.tsx
@@ -144,8 +144,7 @@ const SeatMapConfig: React.FC<SeatMapConfigProps> = ({
       {/* 行数・列数入力エリア */}
       <Paper elevation={2} sx={{ p: 2, mb: 3 }}>
         <Grid container spacing={2} alignItems="center">
-          {/* @ts-ignore */}
-          <Grid item xs={12} sm={6}>
+          <Grid size={{ xs: 12, sm: 6 }}>
             <TextField
               label="行数 (Rows)"
               type="number"
@@ -157,8 +156,7 @@ const SeatMapConfig: React.FC<SeatMapConfigProps> = ({
               helperText={!!errorMessage && errorMessage.includes('行数') ? errorMessage : ' '}
             />
           </Grid>
-          {/* @ts-ignore */}
-          <Grid item xs={12} sm={6}>
+          <Grid size={{ xs: 12, sm: 6 }}>
             <TextField
               label="列数 (Columns)"
               type="number"
@@ -197,8 +195,7 @@ const SeatMapConfig: React.FC<SeatMapConfigProps> = ({
       <Paper elevation={2} sx={{ p: 2, overflowX: 'auto' }}>
         <Grid container spacing={1} justifyContent="center" wrap="wrap">
           {Array.from({ length: rows }).map((_, rowIndex) => (
-            // @ts-ignore
-            <Grid container item xs={12} key={`row-${rowIndex}`} spacing={1} justifyContent="center" wrap="nowrap">
+            <Grid container size={12} key={`row-${rowIndex}`} spacing={1} justifyContent="center" wrap="nowrap">
               {Array.from({ length: cols }).map((_, colIndex) => {
                 const seatId = `R${rowIndex + 1}C${colIndex + 1}`;
                 const seatData = currentEditedSeatMap.find(s => s.seatId === seatId);
@@ -206,22 +203,21 @@ const SeatMapConfig: React.FC<SeatMapConfigProps> = ({
                   seatId: seatId,
                   assignedStudentId: null,
                   isUsable: true,
-                  row: rowIndex + 1, // 行番号を1から始める
-                  col: colIndex + 1, // 列番号を1から始める
+                  row: rowIndex + 1,
+                  col: colIndex + 1,
                 };
 
                 return (
-                  // @ts-ignore
-                  <Grid item key={seatId}>
+                  <Grid key={seatId}>
                     <Seat
                       seatId={seatId}
                       seatData={displaySeatData}
                       assignedStudent={null}
                       onClick={handleSeatClick}
-                      isConfigMode={true} // このコンポーネントでは常に設定モード
-                      isHighlighted={false} // ハイライトは設定モードでは不要
-                      displayMode="config" // 表示モードを設定モードに
-                      isDragDisabled={true} // ドラッグは設定モードでは無効
+                      isConfigMode={true}
+                      isHighlighted={false}
+                      displayMode="config"
+                      isDragDisabled={true}
                     />
                   </Grid>
                 );

--- a/src/components/Student/StudentList.tsx
+++ b/src/components/Student/StudentList.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useMemo } from 'react';
 import {
   List,
   ListItem,
+  ListItemButton,
   ListItemText,
   ListItemIcon,
   Avatar,
@@ -102,56 +103,50 @@ const StudentList: React.FC<StudentListProps> = ({
             <ListItemText secondary={emptyMessage} sx={{ textAlign: 'center', py: 2 }} />
           </ListItem>
         ) : (
-          sortedStudents.map((student) => (
-            // @ts-ignore
-            <ListItem
-              key={student.id}
-              // onStudentClick が設定されている場合のみボタンとして機能させる
-              button={!!onStudentClick}
-              onClick={onStudentClick ? () => handleClick(student.id) : undefined}
-              selected={selectedStudentIds.includes(student.id)}
-              sx={{
-                '&.Mui-selected': {
-                  backgroundColor: (theme) => theme.palette.primary.light + ' !important',
-                  '&:hover': {
-                    backgroundColor: (theme) => theme.palette.primary.light,
-                  },
+          sortedStudents.map((student) => {
+            const selectedSx = {
+              '&.Mui-selected': {
+                backgroundColor: (theme: import('@mui/material/styles').Theme) => theme.palette.primary.light + ' !important',
+                '&:hover': {
+                  backgroundColor: (theme: import('@mui/material/styles').Theme) => theme.palette.primary.light,
                 },
-                cursor: onStudentClick ? 'pointer' : 'default', // クリック可能ならポインター
-              }}
-            >
-              <ListItemIcon>
-                <Avatar>{student.number}</Avatar>
-              </ListItemIcon>
-              <ListItemText
-                primary={`${student.name}`}
-              />
-              {type === 'default' && student.kana && 
-                <ListItemText
-                  secondary={`(${student.kana})`}
-                  sx={{ ml: 2, color: 'text.secondary' }}
-                />
-              }
-              {type === 'default' && student.info1 && 
-                <ListItemText
-                  secondary={`(${student.info1})`}
-                  sx={{ ml: 2, color: 'text.secondary' }}
-                />
-              }
-              {type === 'default' && student.info2 && 
-                <ListItemText
-                  secondary={`(${student.info2})`}
-                  sx={{ ml: 2, color: 'text.secondary' }}
-                />
-              }
-              {type === 'default' && student.info3 && 
-                <ListItemText
-                  secondary={`(${student.info3})`}
-                  sx={{ ml: 2, color: 'text.secondary' }}
-                />
-              }
-            </ListItem>
-          ))
+              },
+            };
+            const content = (
+              <>
+                <ListItemIcon>
+                  <Avatar>{student.number}</Avatar>
+                </ListItemIcon>
+                <ListItemText primary={`${student.name}`} />
+                {type === 'default' && student.kana &&
+                  <ListItemText secondary={`(${student.kana})`} sx={{ ml: 2, color: 'text.secondary' }} />
+                }
+                {type === 'default' && student.info1 &&
+                  <ListItemText secondary={`(${student.info1})`} sx={{ ml: 2, color: 'text.secondary' }} />
+                }
+                {type === 'default' && student.info2 &&
+                  <ListItemText secondary={`(${student.info2})`} sx={{ ml: 2, color: 'text.secondary' }} />
+                }
+                {type === 'default' && student.info3 &&
+                  <ListItemText secondary={`(${student.info3})`} sx={{ ml: 2, color: 'text.secondary' }} />
+                }
+              </>
+            );
+            return onStudentClick ? (
+              <ListItemButton
+                key={student.id}
+                onClick={() => handleClick(student.id)}
+                selected={selectedStudentIds.includes(student.id)}
+                sx={selectedSx}
+              >
+                {content}
+              </ListItemButton>
+            ) : (
+              <ListItem key={student.id} sx={selectedSx}>
+                {content}
+              </ListItem>
+            );
+          })
         )}
       </List>
     </Box>

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -58,11 +58,6 @@ export const AppPhaseIcons: Record<any, React.ComponentType<SvgIconProps>> = {
 // =============================================================================
 
 /**
- * ローカルストレージにデータを保存する際のキー名です。
- */
-export const LOCAL_STORAGE_KEY = 'seatingAppData';
-
-/**
  * 座席表のデフォルトの行数です。
  */
 export const DEFAULT_SEAT_ROWS = 6;


### PR DESCRIPTION
## 何を変えたか

ロードマップに記載の技術的負債を解消し、RelationConfig の無効化済みコードを削除した。

## なぜ変えたか

- RelationConfig は今後仕切り直しのため、古いコメントアウト実装をそのまま残すと混乱の元になる
- `alert()` / `execCommand` は UX・API 両面で非推奨であり、早期に置き換えるべき状態だった
- MUI v7 で旧 Grid API（`item`/`xs`/`md` props）が型エラーとなり、`@ts-ignore` で回避していた箇所を正規の `size` prop に統一した
- 未使用の `setInterval` と定数はコードのノイズになっていた

## 変更内容

| ファイル | 内容 |
|---------|------|
| `App.tsx` | `case AppPhaseConstants.relation` コメントアウトブロックを削除 |
| `Layout.tsx` | `// "relation"` 削除、`alert()` → `Snackbar`+`Alert`、deps 修正 |
| `RouletteDisplay.tsx` | 空の `setInterval` 削除、`Grid` 旧API → 新API、`wrap="no-wrap"` 誤字修正 |
| `FixedSeatConfig.tsx` | `Grid` 旧API → 新API、`ListItem button` → `ListItemButton` |
| `OutputPanel.tsx` | `alert()` → `Snackbar`、`execCommand('copy')` → `navigator.clipboard.writeText()`、`Grid` 新API |
| `SeatMapConfig.tsx` | `Grid` 旧API → 新API |
| `StudentList.tsx` | `ListItem button` → 条件分岐で `ListItemButton`/`ListItem` |
| `constants/index.ts` | 未使用 `LOCAL_STORAGE_KEY` 削除 |

## テスト計画

- [ ] `npm run build` が通ること（確認済み）
- [ ] 生徒読み込み → 座席設定 → 固定座席設定 → ルーレット → 座席表の一連フローを手動確認
- [ ] データ保存・読み込み・リセットで Snackbar が表示されること
- [ ] クリップボードコピーが動作すること（HTTPS または localhost 環境で確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)