### PR TITLE
feat: 座席グリッドに黒板（前）・後ラベルを全フェーズに追加

### DIFF
--- a/src/components/Roulette/RouletteDisplay.tsx
+++ b/src/components/Roulette/RouletteDisplay.tsx
@@ -401,6 +401,9 @@ const RouletteDisplay: React.FC = () => {
 
       {/* 座席グリッド - 画面中央に配置 */}
       <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', overflowX: 'auto', px: 1 }}>
+        <Box sx={{ alignSelf: 'stretch', textAlign: 'center', bgcolor: 'grey.800', color: 'white', py: 0.5, borderRadius: 1, mb: 1 }}>
+          <Typography variant="caption" sx={{ fontWeight: 'bold' }}>黒板（前）</Typography>
+        </Box>
         {Array.from({ length: maxRow }).map((_, rowIndex) => (
           <Box key={`row-${rowIndex}`} sx={{ display: 'flex', gap: 0.5, mb: 0.5 }}>
             {Array.from({ length: maxCol }).map((_, colIndex) => {
@@ -442,6 +445,9 @@ const RouletteDisplay: React.FC = () => {
             })}
           </Box>
         ))}
+        <Box sx={{ alignSelf: 'stretch', textAlign: 'center', mt: 1 }}>
+          <Typography variant="caption" color="text.secondary">後</Typography>
+        </Box>
       </Box>
 
       {/* パネル非表示時: 展開ボタンのみ表示 */}

--- a/src/components/Seat/SeatMapChart.tsx
+++ b/src/components/Seat/SeatMapChart.tsx
@@ -67,55 +67,56 @@ const SeatMapChart: React.FC<SeatMapChartProps> = ({
   const isSeatDroppableInThisMode = isDragAndDropEnabled && (displayMode === 'final'); // D&Dは final モードでのみ有効とする
 
   return (
-    <Box
-      sx={{
-        display: 'grid',
-        // maxCols を使用して動的にカラム数を設定
-        gridTemplateColumns: `repeat(${maxCols}, minmax(80px, 1fr))`,
-        gap: 1.5,
-        p: 2,
-        border: '1px solid #e0e0e0',
-        borderRadius: 2,
-        bgcolor: 'background.paper',
-        width: 'fit-content',
-        boxShadow: 3,
-        overflowX: 'auto',
-      }}
-    >
-      {seatMap.map((seat) => (
-        <Droppable droppableId={seat.seatId} key={seat.seatId} isDropDisabled={!isSeatDroppableInThisMode}>
-          {(provided) => (
-            <div
-              ref={provided.innerRef}
-              {...provided.droppableProps}
-              style={{
-                minHeight: '80px',
-                display: 'flex',
-                justifyContent: 'center',
-                alignItems: 'center',
-              }}
-            >
-              <Seat
-                // seatId と assignedStudentId を直接渡すように変更
-                seatId={seat.seatId}
-                seatData={seat}
-                // 座席の行と列の情報を Seat.tsx に渡す場合
-                // row={/* seatIdから解析するか、別のpropsとしてAppから渡す */}
-                // col={/* seatIdから解析するか、別のpropsとしてAppから渡す */}
-                onClick={onClickSeat ? () => onClickSeat(seat.seatId) : undefined}
-                isConfigMode={displayMode === 'config'}
-                isHighlighted={highlightedSeatIds.has(seat.seatId)}
-                displayMode={displayMode}
-                assignedStudent={seat.assignedStudentId ? studentMap.get(seat.assignedStudentId) : null}
-                // D&Dのドラッグ可能状態をSeatに渡す
-                // 生徒が割り当てられていて、かつ D&Dが有効なフェーズの場合のみドラッグ可能
-                isDragDisabled={!(isDragAndDropEnabled && displayMode === 'final' && seat.assignedStudentId)}
-              />
-              {provided.placeholder}
-            </div>
-          )}
-        </Droppable>
-      ))}
+    <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', width: 'fit-content' }}>
+      <Box sx={{ width: '100%', textAlign: 'center', bgcolor: 'grey.800', color: 'white', py: 0.5, borderRadius: 1, mb: 1 }}>
+        <Typography variant="caption" sx={{ fontWeight: 'bold' }}>黒板（前）</Typography>
+      </Box>
+      <Box
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: `repeat(${maxCols}, minmax(80px, 1fr))`,
+          gap: 1.5,
+          p: 2,
+          border: '1px solid #e0e0e0',
+          borderRadius: 2,
+          bgcolor: 'background.paper',
+          width: 'fit-content',
+          boxShadow: 3,
+          overflowX: 'auto',
+        }}
+      >
+        {seatMap.map((seat) => (
+          <Droppable droppableId={seat.seatId} key={seat.seatId} isDropDisabled={!isSeatDroppableInThisMode}>
+            {(provided) => (
+              <div
+                ref={provided.innerRef}
+                {...provided.droppableProps}
+                style={{
+                  minHeight: '80px',
+                  display: 'flex',
+                  justifyContent: 'center',
+                  alignItems: 'center',
+                }}
+              >
+                <Seat
+                  seatId={seat.seatId}
+                  seatData={seat}
+                  onClick={onClickSeat ? () => onClickSeat(seat.seatId) : undefined}
+                  isConfigMode={displayMode === 'config'}
+                  isHighlighted={highlightedSeatIds.has(seat.seatId)}
+                  displayMode={displayMode}
+                  assignedStudent={seat.assignedStudentId ? studentMap.get(seat.assignedStudentId) : null}
+                  isDragDisabled={!(isDragAndDropEnabled && displayMode === 'final' && seat.assignedStudentId)}
+                />
+                {provided.placeholder}
+              </div>
+            )}
+          </Droppable>
+        ))}
+      </Box>
+      <Box sx={{ width: '100%', textAlign: 'center', mt: 1 }}>
+        <Typography variant="caption" color="text.secondary">後</Typography>
+      </Box>
     </Box>
   );
 };

--- a/src/components/Seat/SeatMapConfig.tsx
+++ b/src/components/Seat/SeatMapConfig.tsx
@@ -193,6 +193,9 @@ const SeatMapConfig: React.FC<SeatMapConfigProps> = ({
         表示されている座席をクリックして、使用不可に設定できます。
       </Typography>
       <Paper elevation={2} sx={{ p: 2, overflowX: 'auto' }}>
+        <Box sx={{ textAlign: 'center', bgcolor: 'grey.800', color: 'white', py: 0.5, borderRadius: 1, mb: 2 }}>
+          <Typography variant="caption" sx={{ fontWeight: 'bold' }}>黒板（前）</Typography>
+        </Box>
         <Grid container spacing={1} justifyContent="center" wrap="wrap">
           {Array.from({ length: rows }).map((_, rowIndex) => (
             <Grid container size={12} key={`row-${rowIndex}`} spacing={1} justifyContent="center" wrap="nowrap">
@@ -225,6 +228,9 @@ const SeatMapConfig: React.FC<SeatMapConfigProps> = ({
             </Grid>
           ))}
         </Grid>
+        <Box sx={{ textAlign: 'center', mt: 2 }}>
+          <Typography variant="caption" color="text.secondary">後</Typography>
+        </Box>
       </Paper>
       {rows * cols > MAX_SEATS && (
           <Alert severity="warning" sx={{ mt: 2 }}>


### PR DESCRIPTION
## 何を変えたか

座席グリッドの上部に「黒板（前）」、下部に「後」のラベルを追加した。

## なぜ変えたか

座席グリッドを見たとき、画面の上下どちらが教室の前方（黒板側）か視覚的に分からなかった。

## 対象フェーズ

- `config` フェーズ（`SeatMapConfig.tsx` 内のグリッド）
- `fixedSeat` / `chart` / `finished` フェーズ（`SeatMapChart.tsx` でラップ）
- `roulette` フェーズ（`RouletteDisplay.tsx` 内のカスタムグリッド）

## ラベルのデザイン

- 上部（前）: ダークグレー背景・白文字・太字「黒板（前）」
- 下部（後）: テキストカラー「後」

🤖 Generated with [Claude Code](https://claude.com/claude-code)