### PR TITLE
feat: 固定座席フェーズの生徒選択を Autocomplete に変更

### DIFF
--- a/src/components/Config/FixedSeatConfig.tsx
+++ b/src/components/Config/FixedSeatConfig.tsx
@@ -4,10 +4,8 @@ import {
   Typography,
   Paper,
   Button,
-  Grid,
   List,
   ListItem,
-  ListItemButton,
   ListItemText,
   ListItemIcon,
   Avatar,
@@ -16,164 +14,107 @@ import {
   AlertTitle,
   Chip,
   Divider,
+  Autocomplete,
+  TextField,
 } from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
 import ClearAllIcon from '@mui/icons-material/ClearAll';
-import ChairIcon from '@mui/icons-material/Chair'; // 座席を示すアイコン
+import ChairIcon from '@mui/icons-material/Chair';
 
 import type { Student } from '../../types/Student';
-import type { SeatMapData } from '../../types/Seat'; // SeatMapData をインポート
-import type { FixedSeatAssignment } from '../../types/Seat'; // 新しく定義した型をインポート
+import type { SeatMapData } from '../../types/Seat';
+import type { FixedSeatAssignment } from '../../types/Seat';
 
-import SeatMapChart from '../Seat/SeatMapChart'; // SeatMapChart をインポート
-import { DragDropContext } from '@hello-pangea/dnd'; // DragDropContext をインポート
+import SeatMapChart from '../Seat/SeatMapChart';
+import { DragDropContext } from '@hello-pangea/dnd';
 
-/**
- * FixedSeatConfigProps インターフェース
- * 固定座席設定コンポーネントが受け取るPropsの型定義です。
- */
 interface FixedSeatConfigProps {
-  /**
-   * 現在の生徒のリストです。
-   */
   students: Student[];
-  /**
-   * 利用可能な座席のマップデータです。
-   */
-  seatMap: SeatMapData[]; // seatCount の代わりに seatMap を受け取る
-
-  /**
-   * 現在の固定座席割り当てデータです。
-   */
+  seatMap: SeatMapData[];
   currentFixedSeatAssignments: FixedSeatAssignment[];
-  /**
-   * 固定座席割り当てが完了し、データが更新されたときに呼び出されるコールバック関数です。
-   */
   onConfigFinished: (updatedConfig: FixedSeatAssignment[]) => void;
-  /**
-   * キャンセル時に呼び出されるコールバック関数です。
-   */
   onCancel: () => void;
 }
 
-/**
- * 生徒の固定座席を設定するコンポーネントです。
- */
 const FixedSeatConfig: React.FC<FixedSeatConfigProps> = ({
   students,
-  seatMap, // Props に seatMap を追加
+  seatMap,
   currentFixedSeatAssignments,
   onConfigFinished,
   onCancel,
 }) => {
-  // 編集中の固定座席割り当てを管理するState
   const [editableFixedSeatAssignments, setEditableFixedSeatAssignments] = useState<FixedSeatAssignment[]>(currentFixedSeatAssignments);
-  // 現在選択中の生徒ID (1人選択)
-  const [selectedStudentId, setSelectedStudentId] = useState<string | null>(null);
-  // 現在選択中の座席ID (1つ選択)
+  const [selectedStudent, setSelectedStudent] = useState<Student | null>(null);
   const [selectedSeatId, setSelectedSeatId] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
-  // 生徒リストを番号順にソート
   const sortedStudents = useMemo(() => {
     return [...students].sort((a, b) => Number(a.number) - Number(b.number));
   }, [students]);
 
-  // 既に割り当て済みの生徒IDのSet
   const assignedStudentIds = useMemo(() => {
     return new Set(editableFixedSeatAssignments.map(assignment => assignment.studentId));
   }, [editableFixedSeatAssignments]);
 
-  // 既に割り当て済みの座席IDのSet
   const assignedSeatIds = useMemo(() => {
     return new Set(editableFixedSeatAssignments.map(assignment => assignment.seatId));
   }, [editableFixedSeatAssignments]);
 
-  // SeatMapChart に渡すハイライトする座席IDのSet
   const highlightedSeatIds = useMemo(() => {
     return selectedSeatId ? new Set([selectedSeatId]) : new Set<string>();
   }, [selectedSeatId]);
 
-
-  // 生徒がクリックされたときのハンドラ
-  const handleStudentClick = useCallback((studentId: string) => {
-    setErrorMessage(null); // エラーメッセージをクリア
-    // 既に割り当て済みの生徒は選択できない
-    if (assignedStudentIds.has(studentId)) {
-      setErrorMessage('この生徒は既に座席に割り当てられています。');
-      return;
-    }
-    setSelectedStudentId((prevSelectedId) => (prevSelectedId === studentId ? null : studentId));
-  }, [assignedStudentIds]);
-
-  // 座席がクリックされたときのハンドラ (SeatMapChartから渡される)
   const handleSeatClick = useCallback((seatId: string) => {
-    setErrorMessage(null); // エラーメッセージをクリア
-    // 既に他の生徒が割り当てられている座席は選択できないようにする
+    setErrorMessage(null);
     if (assignedSeatIds.has(seatId)) {
       setErrorMessage(`座席 ${seatId} は既に他の生徒に割り当てられています。`);
       return;
     }
-    setSelectedSeatId((prevSelectedId) => (prevSelectedId === seatId ? null : seatId));
+    setSelectedSeatId((prev) => (prev === seatId ? null : seatId));
   }, [assignedSeatIds]);
 
-  // 割り当てを追加するハンドラ
   const handleAddAssignment = useCallback(() => {
-    if (!selectedStudentId || !selectedSeatId) {
-      setErrorMessage('生徒と座席をそれぞれ1つずつ選択してください。');
+    if (!selectedStudent || !selectedSeatId) {
+      setErrorMessage('生徒と座席をそれぞれ選択してください。');
       return;
     }
-
-    // 既に選択中の生徒が割り当てられている場合はエラー (handleStudentClickでチェック済みだが念のため)
-    if (assignedStudentIds.has(selectedStudentId)) {
+    if (assignedStudentIds.has(selectedStudent.id)) {
       setErrorMessage('この生徒は既に他の座席に割り当てられています。');
       return;
     }
-    // 既に選択中の座席が割り当てられている場合はエラー (handleSeatClickでチェック済みだが念のため)
     if (assignedSeatIds.has(selectedSeatId)) {
       setErrorMessage('この座席は既に他の生徒に割り当てられています。');
       return;
     }
 
-    setEditableFixedSeatAssignments((prevConfig) => [
-      ...prevConfig,
-      { studentId: selectedStudentId, seatId: selectedSeatId },
+    setEditableFixedSeatAssignments((prev) => [
+      ...prev,
+      { studentId: selectedStudent.id, seatId: selectedSeatId },
     ]);
-    setSelectedStudentId(null); // 割り当て後、選択をクリア
-    setSelectedSeatId(null); // 割り当て後、選択をクリア
+    setSelectedStudent(null);
+    setSelectedSeatId(null);
     setErrorMessage(null);
-  }, [selectedStudentId, selectedSeatId, assignedStudentIds, assignedSeatIds]); // 依存配列に assignedStudentIds, assignedSeatIds を追加
+  }, [selectedStudent, selectedSeatId, assignedStudentIds, assignedSeatIds]);
 
-  // 割り当てを削除するハンドラ
   const handleDeleteAssignment = useCallback((indexToDelete: number) => {
-    setEditableFixedSeatAssignments((prevConfig) =>
-      prevConfig.filter((_, index) => index !== indexToDelete)
+    setEditableFixedSeatAssignments((prev) =>
+      prev.filter((_, index) => index !== indexToDelete)
     );
   }, []);
 
-  // 全ての割り当てをクリアするハンドラ
   const handleClearAllAssignments = useCallback(() => {
     if (window.confirm('全ての固定座席割り当てを削除してもよろしいですか？')) {
       setEditableFixedSeatAssignments([]);
     }
   }, []);
 
-  // 設定を保存するハンドラ
   const handleSaveConfig = useCallback(() => {
     onConfigFinished(editableFixedSeatAssignments);
   }, [editableFixedSeatAssignments, onConfigFinished]);
 
-  // 選択された生徒の名前と座席名を取得
-  const getSelectedInfo = useMemo(() => {
-    const studentName = selectedStudentId ? students.find((s) => s.id === selectedStudentId)?.name || `不明な生徒(${selectedStudentId})` : 'なし';
-    const seatName = selectedSeatId || 'なし';
-    return `選択中: 生徒: ${studentName}, 座席: ${seatName}`;
-  }, [selectedStudentId, selectedSeatId, students]);
-
-  // 割り当てを表示する関数
   const renderAssignment = useCallback((assignment: FixedSeatAssignment, index: number) => {
     const student = students.find(s => s.id === assignment.studentId);
-    if (!student) return null; // 生徒が見つからない場合は表示しない
+    if (!student) return null;
 
     return (
       <ListItem
@@ -202,10 +143,7 @@ const FixedSeatConfig: React.FC<FixedSeatConfigProps> = ({
                 size="small"
               />
               <ChairIcon fontSize="small" color="primary" />
-              <Chip
-                label={assignment.seatId}
-                size="small"
-              />
+              <Chip label={assignment.seatId} size="small" />
             </Box>
           }
         />
@@ -213,10 +151,7 @@ const FixedSeatConfig: React.FC<FixedSeatConfigProps> = ({
     );
   }, [students, handleDeleteAssignment]);
 
-  // DragDropContext の onDragEnd ハンドラ (ここではD&Dを無効にしているため、空の関数でOK)
-  const onDragEnd = useCallback(() => {
-    // このコンポーネントではD&Dは無効化されているため、何もしない
-  }, []);
+  const onDragEnd = useCallback(() => {}, []);
 
   return (
     <Box sx={{ p: 3 }}>
@@ -235,114 +170,77 @@ const FixedSeatConfig: React.FC<FixedSeatConfigProps> = ({
         </Alert>
       )}
 
-      <Grid container spacing={4}>
-        {/* 左側: 生徒リスト */}
-        <Grid size={{ xs: 12, md: 6 }}>
-          <Paper elevation={2} sx={{ p: 2, height: '100%' }}>
-            <Typography variant="h6" gutterBottom>
-              生徒の選択
-            </Typography>
-            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-              座席を割り当てたい生徒を1人選択してください。
-            </Typography>
-            <List sx={{ maxHeight: 500, overflow: 'auto', border: '1px solid #eee', borderRadius: 1 }}>
-              {sortedStudents.length === 0 ? (
-                <ListItem><ListItemText secondary="生徒がいません。最初のステップで生徒を登録してください。" /></ListItem>
-              ) : (
-                sortedStudents.map((student) => (
-                  <ListItemButton
-                    key={student.id}
-                    onClick={() => handleStudentClick(student.id)}
-                    selected={selectedStudentId === student.id}
-                    disabled={assignedStudentIds.has(student.id)}
-                    sx={{
-                      '&.Mui-selected': {
-                        backgroundColor: (theme) => theme.palette.primary.light + ' !important',
-                        '&:hover': {
-                          backgroundColor: (theme) => theme.palette.primary.light,
-                        },
-                      },
-                    }}
-                  >
-                    <ListItemIcon>
-                      <Avatar>{student.number}</Avatar>
-                    </ListItemIcon>
-                    <ListItemText primary={`${student.name}`} />
-                  </ListItemButton>
-                ))
-              )}
-            </List>
-          </Paper>
-        </Grid>
+      {/* 生徒・座席選択エリア */}
+      <Paper elevation={2} sx={{ p: 2, mb: 3 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap' }}>
+          <Autocomplete<Student>
+            options={sortedStudents}
+            getOptionLabel={(s: Student) => `${s.number}番 ${s.name}`}
+            value={selectedStudent}
+            onChange={(_: React.SyntheticEvent, student: Student | null) => {
+              setErrorMessage(null);
+              setSelectedStudent(student);
+            }}
+            getOptionDisabled={(s: Student) => assignedStudentIds.has(s.id)}
+            isOptionEqualToValue={(option: Student, value: Student) => option.id === value.id}
+            size="small"
+            sx={{ minWidth: 240, flexGrow: 1 }}
+            noOptionsText="生徒がいません"
+            renderInput={(params) => <TextField {...params} label="生徒を選択" />}
+          />
+          <Typography variant="body2" color="text.secondary" sx={{ whiteSpace: 'nowrap' }}>
+            座席: {selectedSeatId || '未選択'}
+          </Typography>
+          <Button
+            variant="contained"
+            startIcon={<ChairIcon />}
+            onClick={handleAddAssignment}
+            disabled={!selectedStudent || !selectedSeatId}
+          >
+            割り当てる
+          </Button>
+          <Button
+            variant="outlined"
+            color="inherit"
+            size="small"
+            onClick={() => { setSelectedStudent(null); setSelectedSeatId(null); setErrorMessage(null); }}
+            disabled={!selectedStudent && !selectedSeatId}
+          >
+            選択解除
+          </Button>
+        </Box>
+      </Paper>
 
-        {/* 右側: 座席グリッド (SeatMapChart を使用) */}
-        <Grid size={{ xs: 12, md: 6 }}>
-          <Paper elevation={2} sx={{ p: 2, height: '100%' }}>
-            <Typography variant="h6" gutterBottom>
-              座席の選択
-            </Typography>
-            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-              生徒を座らせたい座席を1つ選択してください。
-            </Typography>
-            {seatMap.length === 0 ? (
-              <Box sx={{ p: 3, textAlign: 'center', mt: 3, width: '100%' }}>
-                <Typography variant="h6" color="text.secondary">
-                  座席マップが設定されていません。
-                </Typography>
-                <Typography variant="body2" color="text.secondary">
-                  「座席レイアウト設定」から座席を作成してください。
-                </Typography>
-              </Box>
-            ) : (
-              <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: 'auto', overflow: 'auto' }}>
-                {/* DragDropContext で SeatMapChart をラップ */}
-                <DragDropContext onDragEnd={onDragEnd}>
-                  <SeatMapChart
-                    seatMap={seatMap.map(seat => ({
-                      ...seat,
-                      // FixedSeatConfig で割り当てられた生徒を SeatMapData に反映させる
-                      assignedStudentId: editableFixedSeatAssignments.find(a => a.seatId === seat.seatId)?.studentId || seat.assignedStudentId
-                    }))}
-                    students={students}
-                    onClickSeat={handleSeatClick}
-                    displayMode="config" // 座席の設定モードとして表示
-                    highlightedSeatIds={highlightedSeatIds} // 選択中の座席をハイライト
-                    isDragAndDropEnabled={false} // 固定座席設定ではD&Dは無効
-                  />
-                </DragDropContext>
-              </Box>
-            )}
-            <Box sx={{ mt: 2, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-              <Typography variant="body2" color="text.secondary">
-                {getSelectedInfo}
-              </Typography>
-              <Button
-                variant="outlined"
-                color="info"
-                size="small"
-                onClick={() => { setSelectedStudentId(null); setSelectedSeatId(null); }}
-                disabled={!selectedStudentId && !selectedSeatId}
-              >
-                選択解除
-              </Button>
-            </Box>
-            <Box sx={{ mt: 2, display: 'flex', gap: 1, justifyContent: 'center' }}>
-              <Button
-                variant="contained"
-                startIcon={<ChairIcon />}
-                onClick={handleAddAssignment}
-                disabled={!selectedStudentId || !selectedSeatId}
-                sx={{ flexGrow: 1 }}
-              >
-                この座席に割り当てる
-              </Button>
-            </Box>
-          </Paper>
-        </Grid>
-      </Grid>
+      {/* 座席グリッド */}
+      {seatMap.length === 0 ? (
+        <Box sx={{ p: 3, textAlign: 'center', mb: 3 }}>
+          <Typography variant="h6" color="text.secondary">
+            座席マップが設定されていません。
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            「座席レイアウト設定」から座席を作成してください。
+          </Typography>
+        </Box>
+      ) : (
+        <Box sx={{ display: 'flex', justifyContent: 'center', mb: 3 }}>
+          <DragDropContext onDragEnd={onDragEnd}>
+            <SeatMapChart
+              seatMap={seatMap.map(seat => ({
+                ...seat,
+                assignedStudentId: editableFixedSeatAssignments.find(a => a.seatId === seat.seatId)?.studentId || seat.assignedStudentId,
+              }))}
+              students={students}
+              onClickSeat={handleSeatClick}
+              displayMode="config"
+              highlightedSeatIds={highlightedSeatIds}
+              isDragAndDropEnabled={false}
+            />
+          </DragDropContext>
+        </Box>
+      )}
 
-      {/* 設定された座席割り当てリスト */}
-      <Paper elevation={2} sx={{ p: 2, mt: 4 }}>
+      {/* 設定済み固定座席リスト */}
+      <Paper elevation={2} sx={{ p: 2, mt: 2 }}>
         <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
           <Typography variant="h6" gutterBottom component="div">
             設定済み固定座席
@@ -367,21 +265,12 @@ const FixedSeatConfig: React.FC<FixedSeatConfigProps> = ({
         </List>
       </Paper>
 
-
       {/* ナビゲーションボタン */}
       <Box sx={{ mt: 4, display: 'flex', justifyContent: 'space-between' }}>
-        <Button
-          variant="outlined"
-          color="secondary"
-          onClick={onCancel}
-        >
+        <Button variant="outlined" color="secondary" onClick={onCancel}>
           キャンセル
         </Button>
-        <Button
-          variant="contained"
-          size="large"
-          onClick={handleSaveConfig}
-        >
+        <Button variant="contained" size="large" onClick={handleSaveConfig}>
           固定座席を確定し次へ
         </Button>
       </Box>

--- a/src/components/Config/FixedSeatConfig.tsx
+++ b/src/components/Config/FixedSeatConfig.tsx
@@ -7,12 +7,9 @@ import {
   List,
   ListItem,
   ListItemText,
-  ListItemIcon,
-  Avatar,
   IconButton,
   Alert,
   AlertTitle,
-  Chip,
   Divider,
   Autocomplete,
   TextField,
@@ -20,6 +17,8 @@ import {
 import DeleteIcon from '@mui/icons-material/Delete';
 import ClearAllIcon from '@mui/icons-material/ClearAll';
 import ChairIcon from '@mui/icons-material/Chair';
+import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 
 import type { Student } from '../../types/Student';
 import type { SeatMapData } from '../../types/Seat';
@@ -47,17 +46,18 @@ const FixedSeatConfig: React.FC<FixedSeatConfigProps> = ({
   const [selectedStudent, setSelectedStudent] = useState<Student | null>(null);
   const [selectedSeatId, setSelectedSeatId] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [sidebarVisible, setSidebarVisible] = useState(true);
 
   const sortedStudents = useMemo(() => {
     return [...students].sort((a, b) => Number(a.number) - Number(b.number));
   }, [students]);
 
   const assignedStudentIds = useMemo(() => {
-    return new Set(editableFixedSeatAssignments.map(assignment => assignment.studentId));
+    return new Set(editableFixedSeatAssignments.map(a => a.studentId));
   }, [editableFixedSeatAssignments]);
 
   const assignedSeatIds = useMemo(() => {
-    return new Set(editableFixedSeatAssignments.map(assignment => assignment.seatId));
+    return new Set(editableFixedSeatAssignments.map(a => a.seatId));
   }, [editableFixedSeatAssignments]);
 
   const highlightedSeatIds = useMemo(() => {
@@ -112,45 +112,6 @@ const FixedSeatConfig: React.FC<FixedSeatConfigProps> = ({
     onConfigFinished(editableFixedSeatAssignments);
   }, [editableFixedSeatAssignments, onConfigFinished]);
 
-  const renderAssignment = useCallback((assignment: FixedSeatAssignment, index: number) => {
-    const student = students.find(s => s.id === assignment.studentId);
-    if (!student) return null;
-
-    return (
-      <ListItem
-        key={index}
-        secondaryAction={
-          <IconButton edge="end" aria-label="delete" onClick={() => handleDeleteAssignment(index)}>
-            <DeleteIcon />
-          </IconButton>
-        }
-      >
-        <ListItemIcon>
-          <ChairIcon color="action" />
-        </ListItemIcon>
-        <ListItemText
-          primary={
-            <Box sx={{ display: 'flex', gap: 1, mt: 0.5 }}>
-              <Typography color='gray'>座席割り当て: </Typography>
-              <Typography>{student.name} を {assignment.seatId} に</Typography>
-            </Box>
-          }
-          secondary={
-            <Box sx={{ display: 'flex', gap: 1, mt: 0.5 }}>
-              <Chip
-                avatar={<Avatar>{student.number}</Avatar>}
-                label={student.name}
-                size="small"
-              />
-              <ChairIcon fontSize="small" color="primary" />
-              <Chip label={assignment.seatId} size="small" />
-            </Box>
-          }
-        />
-      </ListItem>
-    );
-  }, [students, handleDeleteAssignment]);
-
   const onDragEnd = useCallback(() => {}, []);
 
   return (
@@ -170,100 +131,147 @@ const FixedSeatConfig: React.FC<FixedSeatConfigProps> = ({
         </Alert>
       )}
 
-      {/* 生徒・座席選択エリア */}
-      <Paper elevation={2} sx={{ p: 2, mb: 3 }}>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap' }}>
-          <Autocomplete<Student>
-            options={sortedStudents}
-            getOptionLabel={(s: Student) => `${s.number}番 ${s.name}`}
-            value={selectedStudent}
-            onChange={(_: React.SyntheticEvent, student: Student | null) => {
-              setErrorMessage(null);
-              setSelectedStudent(student);
-            }}
-            getOptionDisabled={(s: Student) => assignedStudentIds.has(s.id)}
-            isOptionEqualToValue={(option: Student, value: Student) => option.id === value.id}
-            size="small"
-            sx={{ minWidth: 240, flexGrow: 1 }}
-            noOptionsText="生徒がいません"
-            renderInput={(params) => <TextField {...params} label="生徒を選択" />}
-          />
-          <Typography variant="body2" color="text.secondary" sx={{ whiteSpace: 'nowrap' }}>
-            座席: {selectedSeatId || '未選択'}
-          </Typography>
-          <Button
-            variant="contained"
-            startIcon={<ChairIcon />}
-            onClick={handleAddAssignment}
-            disabled={!selectedStudent || !selectedSeatId}
-          >
-            割り当てる
-          </Button>
-          <Button
-            variant="outlined"
-            color="inherit"
-            size="small"
-            onClick={() => { setSelectedStudent(null); setSelectedSeatId(null); setErrorMessage(null); }}
-            disabled={!selectedStudent && !selectedSeatId}
-          >
-            選択解除
-          </Button>
-        </Box>
-      </Paper>
+      <Box sx={{ display: 'flex', gap: 2, alignItems: 'flex-start' }}>
+        {/* サイドバー: 設定済み固定座席 */}
+        {sidebarVisible && (
+          <Paper elevation={2} sx={{ p: 2, width: 240, flexShrink: 0 }}>
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
+              <Typography variant="subtitle1" sx={{ fontWeight: 'bold' }}>
+                設定済み ({editableFixedSeatAssignments.length}件)
+              </Typography>
+              <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                <IconButton
+                  size="small"
+                  color="warning"
+                  onClick={handleClearAllAssignments}
+                  disabled={editableFixedSeatAssignments.length === 0}
+                  title="全クリア"
+                >
+                  <ClearAllIcon fontSize="small" />
+                </IconButton>
+                <IconButton size="small" onClick={() => setSidebarVisible(false)}>
+                  <ChevronLeftIcon />
+                </IconButton>
+              </Box>
+            </Box>
+            <List dense sx={{ maxHeight: 500, overflow: 'auto', border: '1px solid #eee', borderRadius: 1 }}>
+              {editableFixedSeatAssignments.length === 0 ? (
+                <ListItem>
+                  <ListItemText secondary="まだ設定されていません" secondaryTypographyProps={{ variant: 'caption' }} />
+                </ListItem>
+              ) : (
+                editableFixedSeatAssignments.map((assignment, index) => {
+                  const student = students.find(s => s.id === assignment.studentId);
+                  if (!student) return null;
+                  return (
+                    <ListItem
+                      key={index}
+                      secondaryAction={
+                        <IconButton edge="end" size="small" onClick={() => handleDeleteAssignment(index)}>
+                          <DeleteIcon fontSize="small" />
+                        </IconButton>
+                      }
+                      sx={{ py: 0.5 }}
+                    >
+                      <ListItemText
+                        primary={`${student.number}番 ${student.name}`}
+                        secondary={assignment.seatId}
+                        primaryTypographyProps={{ variant: 'body2', noWrap: true }}
+                        secondaryTypographyProps={{ variant: 'caption' }}
+                      />
+                    </ListItem>
+                  );
+                })
+              )}
+            </List>
+          </Paper>
+        )}
 
-      {/* 座席グリッド */}
-      {seatMap.length === 0 ? (
-        <Box sx={{ p: 3, textAlign: 'center', mb: 3 }}>
-          <Typography variant="h6" color="text.secondary">
-            座席マップが設定されていません。
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            「座席レイアウト設定」から座席を作成してください。
-          </Typography>
-        </Box>
-      ) : (
-        <Box sx={{ display: 'flex', justifyContent: 'center', mb: 3 }}>
-          <DragDropContext onDragEnd={onDragEnd}>
-            <SeatMapChart
-              seatMap={seatMap.map(seat => ({
-                ...seat,
-                assignedStudentId: editableFixedSeatAssignments.find(a => a.seatId === seat.seatId)?.studentId || seat.assignedStudentId,
-              }))}
-              students={students}
-              onClickSeat={handleSeatClick}
-              displayMode="config"
-              highlightedSeatIds={highlightedSeatIds}
-              isDragAndDropEnabled={false}
-            />
-          </DragDropContext>
-        </Box>
-      )}
-
-      {/* 設定済み固定座席リスト */}
-      <Paper elevation={2} sx={{ p: 2, mt: 2 }}>
-        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
-          <Typography variant="h6" gutterBottom component="div">
-            設定済み固定座席
-          </Typography>
-          <Button
-            variant="outlined"
-            color="warning"
-            startIcon={<ClearAllIcon />}
-            onClick={handleClearAllAssignments}
-            disabled={editableFixedSeatAssignments.length === 0}
-            size="small"
-          >
-            全クリア
-          </Button>
-        </Box>
-        <List sx={{ maxHeight: 400, overflow: 'auto', border: '1px solid #eee', borderRadius: 1 }}>
-          {editableFixedSeatAssignments.length === 0 ? (
-            <ListItem><ListItemText secondary="まだ固定座席は設定されていません。" /></ListItem>
-          ) : (
-            editableFixedSeatAssignments.map((assignment, index) => renderAssignment(assignment, index))
+        {/* メインコンテンツ */}
+        <Box sx={{ flexGrow: 1, minWidth: 0 }}>
+          {/* サイドバー非表示時の展開ボタン */}
+          {!sidebarVisible && (
+            <Button
+              size="small"
+              variant="outlined"
+              startIcon={<ChevronRightIcon />}
+              onClick={() => setSidebarVisible(true)}
+              sx={{ mb: 2 }}
+            >
+              設定済み固定座席 ({editableFixedSeatAssignments.length}件)
+            </Button>
           )}
-        </List>
-      </Paper>
+
+          {/* 生徒・座席選択エリア */}
+          <Paper elevation={2} sx={{ p: 2, mb: 3 }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap' }}>
+              <Autocomplete<Student>
+                options={sortedStudents}
+                getOptionLabel={(s: Student) => `${s.number}番 ${s.name}`}
+                value={selectedStudent}
+                onChange={(_: React.SyntheticEvent, student: Student | null) => {
+                  setErrorMessage(null);
+                  setSelectedStudent(student);
+                }}
+                getOptionDisabled={(s: Student) => assignedStudentIds.has(s.id)}
+                isOptionEqualToValue={(option: Student, value: Student) => option.id === value.id}
+                size="small"
+                sx={{ minWidth: 200, flexGrow: 1 }}
+                noOptionsText="生徒がいません"
+                renderInput={(params) => <TextField {...params} label="生徒を選択" />}
+              />
+              <Typography variant="body2" color="text.secondary" sx={{ whiteSpace: 'nowrap' }}>
+                座席: {selectedSeatId || '未選択'}
+              </Typography>
+              <Button
+                variant="contained"
+                startIcon={<ChairIcon />}
+                onClick={handleAddAssignment}
+                disabled={!selectedStudent || !selectedSeatId}
+              >
+                割り当てる
+              </Button>
+              <Button
+                variant="outlined"
+                color="inherit"
+                size="small"
+                onClick={() => { setSelectedStudent(null); setSelectedSeatId(null); setErrorMessage(null); }}
+                disabled={!selectedStudent && !selectedSeatId}
+              >
+                選択解除
+              </Button>
+            </Box>
+          </Paper>
+
+          {/* 座席グリッド */}
+          {seatMap.length === 0 ? (
+            <Box sx={{ p: 3, textAlign: 'center' }}>
+              <Typography variant="h6" color="text.secondary">
+                座席マップが設定されていません。
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                「座席レイアウト設定」から座席を作成してください。
+              </Typography>
+            </Box>
+          ) : (
+            <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+              <DragDropContext onDragEnd={onDragEnd}>
+                <SeatMapChart
+                  seatMap={seatMap.map(seat => ({
+                    ...seat,
+                    assignedStudentId: editableFixedSeatAssignments.find(a => a.seatId === seat.seatId)?.studentId || seat.assignedStudentId,
+                  }))}
+                  students={students}
+                  onClickSeat={handleSeatClick}
+                  displayMode="config"
+                  highlightedSeatIds={highlightedSeatIds}
+                  isDragAndDropEnabled={false}
+                />
+              </DragDropContext>
+            </Box>
+          )}
+        </Box>
+      </Box>
 
       {/* ナビゲーションボタン */}
       <Box sx={{ mt: 4, display: 'flex', justifyContent: 'space-between' }}>


### PR DESCRIPTION
## 何を変えたか

固定座席設定フェーズの生徒選択を、リスト形式から MUI `Autocomplete`（検索付きプルダウン）に変更した。

## なぜ変えたか

生徒リストがリスト形式で常時表示されており、画面スペースを大きく占有していた。Autocomplete にすることで省スペース化し、名前・番号での絞り込み検索も可能になる。

## 主な変更点

- 2カラムレイアウト（生徒リスト | 座席グリッド）を廃止
- 上部に Autocomplete 選択バー（生徒選択・選択中座席表示・割り当てボタン・選択解除ボタン）
- 下部に座席グリッド（全幅表示）
- 割り当て済みの生徒は Autocomplete 内で disabled 表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)