### PR TITLE
feat: jsPDFを廃止しCSS @media print による印刷対応に切り替え

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,6 @@
         "@hello-pangea/dnd": "^18.0.1",
         "@mui/icons-material": "^7.1.0",
         "@mui/material": "^7.1.0",
-        "html2canvas": "^1.4.1",
-        "jspdf": "^3.0.1",
         "papaparse": "^5.5.2",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
@@ -1844,13 +1842,6 @@
       "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
       "license": "MIT"
     },
-    "node_modules/@types/raf": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
-      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/@types/react": {
       "version": "19.1.4",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.4.tgz",
@@ -1888,13 +1879,6 @@
       "peerDependencies": {
         "@types/react": "*"
       }
-    },
-    "node_modules/@types/trusted-types": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
-      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
@@ -2214,18 +2198,6 @@
       "dev": true,
       "license": "Python-2.0"
     },
-    "node_modules/atob": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-      "license": "(MIT OR Apache-2.0)",
-      "bin": {
-        "atob": "bin/atob.js"
-      },
-      "engines": {
-        "node": ">= 4.5.0"
-      }
-    },
     "node_modules/babel-plugin-macros": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
@@ -2247,15 +2219,6 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/base64-arraybuffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
-      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -2314,18 +2277,6 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
-    "node_modules/btoa": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
-      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
-      "license": "(MIT OR Apache-2.0)",
-      "bin": {
-        "btoa": "bin/btoa.js"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2355,26 +2306,6 @@
         }
       ],
       "license": "CC-BY-4.0"
-    },
-    "node_modules/canvg": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
-      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "@types/raf": "^3.4.0",
-        "core-js": "^3.8.3",
-        "raf": "^3.4.1",
-        "regenerator-runtime": "^0.13.7",
-        "rgbcolor": "^1.0.1",
-        "stackblur-canvas": "^2.0.0",
-        "svg-pathdata": "^6.0.3"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -2436,18 +2367,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/core-js": {
-      "version": "3.42.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.42.0.tgz",
-      "integrity": "sha512-Sz4PP4ZA+Rq4II21qkNqOEDTDrCvcANId3xpIgB34NDkWc3UduWj2dqEtN9yZIq8Dk3HyPI33x9sqqU5C8sr0g==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
-      }
-    },
     "node_modules/cosmiconfig": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
@@ -2497,15 +2416,6 @@
         "tiny-invariant": "^1.0.6"
       }
     },
-    "node_modules/css-line-break": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
-      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
-      "license": "MIT",
-      "dependencies": {
-        "utrie": "^1.0.2"
-      }
-    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
@@ -2544,16 +2454,6 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
-      }
-    },
-    "node_modules/dompurify": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
-      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
-      "license": "(MPL-2.0 OR Apache-2.0)",
-      "optional": true,
-      "optionalDependencies": {
-        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -2874,12 +2774,6 @@
         "reusify": "^1.0.4"
       }
     },
-    "node_modules/fflate": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
-      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
-      "license": "MIT"
-    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -3054,19 +2948,6 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
-    "node_modules/html2canvas": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
-      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
-      "license": "MIT",
-      "dependencies": {
-        "css-line-break": "^2.1.0",
-        "text-segmentation": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3233,24 +3114,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/jspdf": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-3.0.1.tgz",
-      "integrity": "sha512-qaGIxqxetdoNnFQQXxTKUD9/Z7AloLaw94fFsOiJMxbfYdBbrBuhWmbzI8TVjrw7s3jBY1PFHofBKMV/wZPapg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.26.7",
-        "atob": "^2.1.2",
-        "btoa": "^1.2.1",
-        "fflate": "^0.8.1"
-      },
-      "optionalDependencies": {
-        "canvg": "^3.0.11",
-        "core-js": "^3.6.0",
-        "dompurify": "^3.2.4",
-        "html2canvas": "^1.0.0-rc.5"
       }
     },
     "node_modules/keyv": {
@@ -3534,13 +3397,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -3647,16 +3503,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/raf": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
-      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "performance-now": "^2.1.0"
-      }
-    },
     "node_modules/raf-schd": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
@@ -3745,13 +3591,6 @@
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
       "license": "MIT"
     },
-    "node_modules/regenerator-runtime": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/resolve": {
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
@@ -3790,16 +3629,6 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/rgbcolor": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
-      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
-      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
-      "optional": true,
-      "engines": {
-        "node": ">= 0.8.15"
       }
     },
     "node_modules/rollup": {
@@ -3924,16 +3753,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/stackblur-canvas": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
-      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=0.1.14"
-      }
-    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -3976,25 +3795,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/svg-pathdata": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
-      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/text-segmentation": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
-      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
-      "license": "MIT",
-      "dependencies": {
-        "utrie": "^1.0.2"
       }
     },
     "node_modules/tiny-invariant": {
@@ -4181,15 +3981,6 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/utrie": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
-      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
-      "license": "MIT",
-      "dependencies": {
-        "base64-arraybuffer": "^1.0.2"
-      }
-    },
     "node_modules/vite": {
       "version": "6.3.5",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
@@ -4325,21 +4116,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
-      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,6 @@
     "@hello-pangea/dnd": "^18.0.1",
     "@mui/icons-material": "^7.1.0",
     "@mui/material": "^7.1.0",
-    "html2canvas": "^1.4.1",
-    "jspdf": "^3.0.1",
     "papaparse": "^5.5.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"

--- a/src/components/Output/OutputPanel.tsx
+++ b/src/components/Output/OutputPanel.tsx
@@ -1,4 +1,3 @@
-// src/components/output/OutputPanel.tsx
 import React, { useState, useCallback, useMemo } from 'react';
 import {
   Box,
@@ -12,21 +11,14 @@ import {
   Snackbar,
   Alert,
 } from '@mui/material';
-import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf';
+import PrintIcon from '@mui/icons-material/Print';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import { useAppState } from '../../contexts/AppStateContext';
 import PrintableSeatChart from './PrintableSeatChart';
 
-// PDF生成ライブラリ (例: jsPDFとhtml2canvas)
-// プロジェクトにインストールが必要です:
-// npm install jspdf html2canvas
-import jsPDF from 'jspdf';
-import html2canvas from 'html2canvas';
-
-// 出力可能な生徒情報の項目
 interface StudentOutputFields {
   id: boolean;
-  number: boolean; // 出席番号など
+  number: boolean;
   name: boolean;
   kana: boolean;
   info1: boolean;
@@ -39,8 +31,8 @@ const OutputPanel: React.FC = () => {
 
   const [selectedFields, setSelectedFields] = useState<StudentOutputFields>({
     id: false,
-    number: true, // デフォルトで出席番号を表示
-    name: true, // デフォルトで名前を表示
+    number: true,
+    name: true,
     kana: false,
     info1: false,
     info2: false,
@@ -54,92 +46,23 @@ const OutputPanel: React.FC = () => {
 
   const handleFieldChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
-      setSelectedFields({
-        ...selectedFields,
-        [event.target.name]: event.target.checked,
-      });
+      setSelectedFields(prev => ({ ...prev, [event.target.name]: event.target.checked }));
     },
+    []
+  );
+
+  const hasSelectedFields = useMemo(
+    () => Object.values(selectedFields).some(v => v),
     [selectedFields]
   );
 
-  // 選択された項目があるかどうかの判定 (ボタンの disabled 状態に使用)
-  const hasSelectedFields = useMemo(() => {
-    return Object.values(selectedFields).some((isChecked) => isChecked);
-  }, [selectedFields]);
-
-  // 座席表データと生徒情報を結合し、表示形式に整形する関数
-  // この関数は、PDF出力とコピー機能で共通して使用します。
-  const getOutputTableData = useCallback(() => {
-    const tableData: { [key: string]: string | number | null }[][] = [];
-    const maxRow = Math.max(...seatMap.map((seat) => seat.row));
-    const maxCol = Math.max(...seatMap.map((seat) => seat.col));
-
-    for (let r = 1; r <= maxRow; r++) {
-      const rowData: { [key: string]: string | number | null }[] = [];
-      for (let c = 1; c <= maxCol; c++) {
-        const seat = seatMap.find((s) => s.row === r && s.col === c && s.isUsable);
-        let cellData: { [key: string]: string | number | null } = {
-          seatId: seat ? seat.seatId : null,
-          row: r,
-          col: c,
-        };
-
-        if (seat && seat.assignedStudentId) {
-          const student = students.find((s) => s.id === seat.assignedStudentId);
-          if (student) {
-            // 選択されたフィールドのみをセルデータに追加
-            if (selectedFields.id) cellData.id = student.id;
-            if (selectedFields.number) cellData.number = student.number;
-            if (selectedFields.name) cellData.name = student.name;
-            if (selectedFields.kana) cellData.kana = student.kana;
-            if (selectedFields.info1) cellData.info1 = student.info1;
-            if (selectedFields.info2) cellData.info2 = student.info2;
-            if (selectedFields.info3) cellData.info3 = student.info3;
-          }
-        }
-        rowData.push(cellData);
-      }
-      tableData.push(rowData);
-    }
-    return tableData;
-  }, [students, seatMap, selectedFields]);
-
-  const handleGeneratePdf = useCallback(async () => {
+  const handlePrint = useCallback(() => {
     if (!hasSelectedFields) {
       showSnackbar('表示したい項目を選択してください。', 'warning');
       return;
     }
-
-    const input = document.getElementById('main-seating-chart-container');
-    if (!input) {
-      showSnackbar('PDF出力元の要素が見つかりません。', 'error');
-      return;
-    }
-
-    try {
-      const canvas = await html2canvas(input, {
-        scale: 2,
-        useCORS: true,
-        logging: true,
-      });
-      const imgData = canvas.toDataURL('image/jpeg');
-      const pdf = new jsPDF({
-        orientation: 'landscape',
-        unit: 'mm',
-        format: 'a4',
-      });
-
-      const imgWidth = 297;
-      const imgHeight = (canvas.height * imgWidth) / canvas.width;
-      const margin = 10;
-      pdf.addImage(imgData, 'PNG', margin, margin, imgWidth - 2 * margin, imgHeight - 2 * margin);
-      pdf.save('seat-arrangement-chart.pdf');
-    } catch (error) {
-      console.error('PDF生成中にエラーが発生しました:', error);
-      showSnackbar('PDFの生成に失敗しました。', 'error');
-    }
+    window.print();
   }, [hasSelectedFields, showSnackbar]);
-
 
   const handleCopyToClipboard = useCallback(async () => {
     if (!hasSelectedFields) {
@@ -162,58 +85,44 @@ const OutputPanel: React.FC = () => {
 
     for (let r = 1; r <= maxRow; r++) {
       activeFieldKeys.forEach(field => {
-        const fieldDataRow: (string | number | null)[] = [field.label];
-
+        const row: (string | number | null)[] = [field.label];
         for (let c = 1; c <= maxCol; c++) {
           const seat = seatMap.find((s) => s.row === r && s.col === c && s.isUsable);
-          const student = seat && seat.assignedStudentId
+          const student = seat?.assignedStudentId
             ? students.find((s) => s.id === seat.assignedStudentId)
             : null;
-
           if (seat) {
-            if (student) {
-              const value = student[field.key as 'id' | 'number' | 'name' | 'kana' | 'info1' | 'info2' | 'info3'];
-              fieldDataRow.push(value ?? '');
-            } else {
-              fieldDataRow.push('空席');
-            }
+            row.push(student ? (student[field.key as 'id' | 'number' | 'name' | 'kana' | 'info1' | 'info2' | 'info3'] ?? '') : '空席');
           } else {
-            fieldDataRow.push('使用不可');
+            row.push('使用不可');
           }
         }
-        csvContent += fieldDataRow.map(v => (v === null || v === undefined) ? '' : String(v)).join('\t') + '\n';
+        csvContent += row.map(v => (v === null || v === undefined) ? '' : String(v)).join('\t') + '\n';
       });
     }
 
     try {
       await navigator.clipboard.writeText(csvContent);
       showSnackbar('座席データがクリップボードにコピーされました！表計算ソフトに貼り付けてください。', 'success');
-    } catch (err) {
-      console.error('クリップボードへのコピーに失敗しました:', err);
+    } catch {
       showSnackbar('クリップボードへのコピーに失敗しました。', 'error');
     }
   }, [hasSelectedFields, seatMap, students, selectedFields, showSnackbar]);
 
   return (
     <>
-      {/* 既存の出力オプションコントロール */}
-      <Paper elevation={3} sx={{ p: 3, my: 3, display: 'flex', flexDirection: 'column', gap: 2 }}>
+      {/* 印刷時には非表示にする操作パネル */}
+      <Paper elevation={3} sx={{ p: 3, my: 3, display: 'flex', flexDirection: 'column', gap: 2, '@media print': { display: 'none' } }}>
         <Typography variant="h6" gutterBottom align="center">
           座席表出力オプション
         </Typography>
 
         <Typography variant="subtitle1" sx={{ mb: 1 }}>表示項目を選択:</Typography>
         <Grid container spacing={1}>
-          {Object.entries(selectedFields).map(([key, value]) => (
+          {(Object.entries(selectedFields) as [keyof StudentOutputFields, boolean][]).map(([key, value]) => (
             <Grid size={{ xs: 4, sm: 2 }} key={key}>
               <FormControlLabel
-                control={
-                  <Checkbox
-                    checked={value}
-                    onChange={handleFieldChange}
-                    name={key}
-                  />
-                }
+                control={<Checkbox checked={value} onChange={handleFieldChange} name={key} />}
                 label={
                   key === 'id' ? '生徒ID' :
                   key === 'number' ? '出席番号' :
@@ -227,101 +136,50 @@ const OutputPanel: React.FC = () => {
         </Grid>
 
         <Box sx={{ display: 'flex', justifyContent: 'center', gap: 2, mt: 2 }}>
-          <Tooltip title={hasSelectedFields ? "現在の座席表をPDFで出力" : "出力項目を選択してください"}>
-            <Button
-              variant="contained"
-              color="primary"
-              onClick={handleGeneratePdf}
-              startIcon={<PictureAsPdfIcon />}
-              disabled={!hasSelectedFields}
-            >
-              PDF出力
-            </Button>
+          <Tooltip title={hasSelectedFields ? '座席表を印刷' : '出力項目を選択してください'}>
+            <span>
+              <Button
+                variant="contained"
+                color="primary"
+                onClick={handlePrint}
+                startIcon={<PrintIcon />}
+                disabled={!hasSelectedFields}
+              >
+                印刷
+              </Button>
+            </span>
           </Tooltip>
-          <Tooltip title={hasSelectedFields ? "座席データを表計算ソフト用にコピー" : "出力項目を選択してください"}>
-            <Button
-              variant="contained"
-              color="primary"
-              onClick={handleCopyToClipboard}
-              startIcon={<ContentCopyIcon />}
-              disabled={!hasSelectedFields}
-            >
-              コピー
-            </Button>
+          <Tooltip title={hasSelectedFields ? '座席データを表計算ソフト用にコピー' : '出力項目を選択してください'}>
+            <span>
+              <Button
+                variant="contained"
+                color="primary"
+                onClick={handleCopyToClipboard}
+                startIcon={<ContentCopyIcon />}
+                disabled={!hasSelectedFields}
+              >
+                コピー
+              </Button>
+            </span>
           </Tooltip>
         </Box>
       </Paper>
 
-      {/* main-seating-chart-container: 座席表プレビューと詳細データ表示用 */}
-      <Paper elevation={3} sx={{ p: 3, my: 3 }}>
-        <Typography variant="h6" gutterBottom align="center">
-          座席表プレビューと詳細データ
-        </Typography>
-        <div
-          style={{overflow: 'scroll'}}
-        >
-          <div id="main-seating-chart-container" style={{ padding: '20px', overflowX: 'scroll', width: '1181px' }}>
-            {/* 視覚的な座席表 */}
-            <Typography variant="h6" gutterBottom sx={{ mb: 2 }}>座席表</Typography>
-            <Typography variant="h5"  sx={{ my: 2, mx: 32, p: 1, border: 2, textAlign: "center" }}>教卓</Typography>
+      {/* 印刷対象エリア。@media print で#print-area だけが表示される */}
+      <div id="print-area">
+        <Paper elevation={3} sx={{ p: 3, my: 3, '@media print': { boxShadow: 'none', margin: 0, padding: 0 } }}>
+          <Typography variant="h6" gutterBottom align="center" sx={{ '@media print': { display: 'none' } }}>
+            座席表プレビュー
+          </Typography>
+          <Box sx={{ overflowX: 'auto' }}>
             <PrintableSeatChart
               seatMap={seatMap}
               students={students}
               selectedFields={selectedFields}
             />
-
-          </div>
-        </div>
-        {/* 詳細データテーブル */}
-        {hasSelectedFields ? (
-          <>
-            <Typography variant="h6" gutterBottom sx={{ mt: 4, mb: 2 }}>座席詳細データ</Typography>
-            <div style={{ overflowX: 'auto' }}> {/* 小さい画面での横スクロールを可能にする */}
-              <table style={{ width: '100%', borderCollapse: 'collapse', border: '1px solid #ddd' }}>
-                <thead>
-                  <tr style={{ backgroundColor: '#f2f2f2' }}>
-                    <th style={{ border: '1px solid #ddd', padding: '8px', textAlign: 'left' }}>行</th>
-                    <th style={{ border: '1px solid #ddd', padding: '8px', textAlign: 'left' }}>列</th>
-                    {selectedFields.id && <th style={{ border: '1px solid #ddd', padding: '8px', textAlign: 'left' }}>生徒ID</th>}
-                    {selectedFields.number && <th style={{ border: '1px solid #ddd', padding: '8px', textAlign: 'left' }}>出席番号</th>}
-                    {selectedFields.name && <th style={{ border: '1px solid #ddd', padding: '8px', textAlign: 'left' }}>名前</th>}
-                    {selectedFields.kana && <th style={{ border: '1px solid #ddd', padding: '8px', textAlign: 'left' }}>フリガナ</th>}
-                    {selectedFields.info1 && <th style={{ border: '1px solid #ddd', padding: '8px', textAlign: 'left' }}>情報1</th>}
-                    {selectedFields.info2 && <th style={{ border: '1px solid #ddd', padding: '8px', textAlign: 'left' }}>情報2</th>}
-                    {selectedFields.info3 && <th style={{ border: '1px solid #ddd', padding: '8px', textAlign: 'left' }}>情報3</th>}
-                  </tr>
-                </thead>
-                <tbody>
-                  {/* getOutputTableDataの結果をフラット化し、各座席データをテーブルの行として表示 */}
-                  {getOutputTableData().flat().map((seatCellData, index) => {
-                    // isUsableがfalseの座席や、生徒が割り当てられていない座席はテーブルに表示しない
-                    if (seatCellData.seatId === null && seatCellData.assignedStudentId === null) {
-                      return null;
-                    }
-                    return (
-                      <tr key={index} style={{ borderBottom: '1px solid #eee' }}>
-                        <td style={{ border: '1px solid #ddd', padding: '8px' }}>{seatCellData.row}</td>
-                        <td style={{ border: '1px solid #ddd', padding: '8px' }}>{seatCellData.col}</td>
-                        {selectedFields.id && <td style={{ border: '1px solid #ddd', padding: '8px' }}>{seatCellData.id ?? ''}</td>}
-                        {selectedFields.number && <td style={{ border: '1px solid #ddd', padding: '8px' }}>{seatCellData.number ?? ''}</td>}
-                        {selectedFields.name && <td style={{ border: '1px solid #ddd', padding: '8px' }}>{seatCellData.name ?? ''}</td>}
-                        {selectedFields.kana && <td style={{ border: '1px solid #ddd', padding: '8px' }}>{seatCellData.kana ?? ''}</td>}
-                        {selectedFields.info1 && <td style={{ border: '1px solid #ddd', padding: '8px' }}>{seatCellData.info1 ?? ''}</td>}
-                        {selectedFields.info2 && <td style={{ border: '1px solid #ddd', padding: '8px' }}>{seatCellData.info2 ?? ''}</td>}
-                        {selectedFields.info3 && <td style={{ border: '1px solid #ddd', padding: '8px' }}>{seatCellData.info3 ?? ''}</td>}
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
-            </div>
-          </>
-        ) : (
-          <Typography variant="body1" color="textSecondary" sx={{ mt: 4, textAlign: 'center' }}>
-            表示する項目を選択すると、詳細データが表示されます。
-          </Typography>
-        )}
-      </Paper>
+          </Box>
+        </Paper>
+      </div>
 
       <Snackbar
         open={snackbar.open}

--- a/src/components/Output/OutputPanel.tsx
+++ b/src/components/Output/OutputPanel.tsx
@@ -10,6 +10,7 @@ import {
   Tooltip,
   Snackbar,
   Alert,
+  TextField,
 } from '@mui/material';
 import PrintIcon from '@mui/icons-material/Print';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
@@ -38,6 +39,8 @@ const OutputPanel: React.FC = () => {
     info2: false,
     info3: false,
   });
+  const [topText, setTopText] = useState('');
+  const [bottomText, setBottomText] = useState('');
   const [snackbar, setSnackbar] = useState<{ open: boolean; message: string; severity: 'success' | 'error' | 'warning' | 'info' }>({ open: false, message: '', severity: 'info' });
 
   const showSnackbar = useCallback((message: string, severity: 'success' | 'error' | 'warning' | 'info') => {
@@ -165,19 +168,52 @@ const OutputPanel: React.FC = () => {
         </Box>
       </Paper>
 
-      {/* 印刷対象エリア。@media print で#print-area だけが表示される */}
+      {/* 印刷対象エリア。@media print で #print-area だけが表示される */}
       <div id="print-area">
         <Paper elevation={3} sx={{ p: 3, my: 3, '@media print': { boxShadow: 'none', margin: 0, padding: 0 } }}>
           <Typography variant="h6" gutterBottom align="center" sx={{ '@media print': { display: 'none' } }}>
             座席表プレビュー
           </Typography>
-          <Box sx={{ overflowX: 'auto' }}>
+
+          {/* 上部テキストボックス（タイトル欄） */}
+          <TextField
+            fullWidth
+            variant="standard"
+            placeholder="〇年〇組 座席表"
+            value={topText}
+            onChange={(e) => setTopText(e.target.value)}
+            inputProps={{ style: { textAlign: 'center', fontSize: '1.2rem', fontWeight: 'bold' } }}
+            sx={{
+              mb: 2,
+              '@media print': {
+                '& .MuiInput-underline::before, & .MuiInput-underline::after': { display: 'none' },
+              },
+            }}
+          />
+
+          <Box className="print-chart-wrapper" sx={{ overflowX: 'auto' }}>
             <PrintableSeatChart
               seatMap={seatMap}
               students={students}
               selectedFields={selectedFields}
             />
           </Box>
+
+          {/* 下部テキストボックス（備考欄） */}
+          <TextField
+            fullWidth
+            variant="standard"
+            placeholder="〇月〇日から"
+            value={bottomText}
+            onChange={(e) => setBottomText(e.target.value)}
+            inputProps={{ style: { textAlign: 'center' } }}
+            sx={{
+              mt: 2,
+              '@media print': {
+                '& .MuiInput-underline::before, & .MuiInput-underline::after': { display: 'none' },
+              },
+            }}
+          />
         </Paper>
       </div>
 

--- a/src/components/Output/PrintableSeatChart.tsx
+++ b/src/components/Output/PrintableSeatChart.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import type { Student } from '../../types/Student';
 import type { SeatMapData } from '../../types/Seat';
 
-// 生徒出力フィールドのインターフェースを定義
 interface StudentOutputFields {
   id: boolean;
   number: boolean;
@@ -13,115 +12,99 @@ interface StudentOutputFields {
   info3: boolean;
 }
 
-// PrintableSeatChartコンポーネントのプロパティを定義
 interface PrintableSeatChartProps {
-  seatMap: SeatMapData[]; // 座席マップデータ
-  students: Student[];     // 生徒データ
-  selectedFields: StudentOutputFields; // 表示する生徒情報の選択状態
+  seatMap: SeatMapData[];
+  students: Student[];
+  selectedFields: StudentOutputFields;
 }
 
-/**
- * 印刷・PDF出力用の座席表コンポーネント。
- * SeatMapChartとは異なり、選択された生徒情報を各座席に表示します。
- */
 const PrintableSeatChart: React.FC<PrintableSeatChartProps> = ({
   seatMap,
   students,
   selectedFields,
 }) => {
-  // 座席マップの最大行と最大列を計算
   const maxRow = Math.max(...seatMap.map((seat) => seat.row));
   const maxCol = Math.max(...seatMap.map((seat) => seat.col));
 
-  // CSS Gridのテンプレート列を動的に生成
-  // 各列の幅を自動調整し、最小100pxを確保
-  const gridTemplateColumns = `repeat(${maxCol}, minmax(100px, 1fr))`;
-
   return (
-    <div>
-      <div style={{ backgroundColor: '#424242', color: '#fff', textAlign: 'center', padding: '4px 0', borderRadius: '4px', marginBottom: '8px', fontSize: '0.85em' }}>
+    <div className="print-chart-root" style={{ display: 'flex', flexDirection: 'column' }}>
+      <div style={{ border: '1px solid #555', color: '#333', textAlign: 'center', padding: '4px 0', marginBottom: '6px', fontSize: '0.85em', fontWeight: 'bold' }}>
         黒板（前）
       </div>
+
+      {/* CSS変数 --seat-cols で列数を @media print の CSS に伝達する */}
       <div
+        className="print-seat-grid"
         style={{
+          '--seat-cols': maxCol,
           display: 'grid',
-          gridTemplateColumns: gridTemplateColumns,
-          gap: '8px',
-          border: '1px solid #ccc',
-          padding: '8px',
-          backgroundColor: '#f9f9f9',
-        }}
+          gridTemplateColumns: `repeat(${maxCol}, minmax(80px, 1fr))`,
+          gap: '6px',
+          padding: '4px',
+          flex: 1,
+        } as React.CSSProperties}
       >
-      {/* 最大行と最大列に基づいてグリッドセルを生成 */}
-      {Array.from({ length: maxRow * maxCol }).map((_, index) => {
-        const r = Math.floor(index / maxCol) + 1; // 現在の行番号
-        const c = (index % maxCol) + 1; // 現在の列番号
+        {Array.from({ length: maxRow * maxCol }).map((_, index) => {
+          const r = Math.floor(index / maxCol) + 1;
+          const c = (index % maxCol) + 1;
 
-        // 現在のセルに対応する座席情報を検索 (isUsableな座席のみ)
-        const seat = seatMap.find((s) => s.row === r && s.col === c && s.isUsable);
-        // 座席に割り当てられた生徒情報を検索
-        const student = seat && seat.assignedStudentId
-          ? students.find((s) => s.id === seat.assignedStudentId)
-          : null;
+          const seat = seatMap.find((s) => s.row === r && s.col === c && s.isUsable);
+          const student = seat?.assignedStudentId
+            ? students.find((s) => s.id === seat.assignedStudentId)
+            : null;
 
-        return (
-          <div
-            key={`${r}-${c}`} // 一意のキー
-            style={{
-              border: '1px solid #ddd', // 座席の枠線
-              borderRadius: '8px', // 角丸
-              padding: '10px', // 座席内の余白
-              aspectRatio: '16/11',
-              minHeight: '80px', // 最小高さ
-              display: 'flex',
-              flexDirection: 'column',
-              justifyContent: 'center',
-              alignItems: 'center',
-              backgroundColor: seat ? '#fff' : '#eee', // 使用可能座席は白、使用不可座席は灰色
-              boxShadow: seat ? '0 2px 4px rgba(0,0,0,0.1)' : 'none', // 影
-              textAlign: 'center', // テキスト中央揃え
-              fontSize: '0.9em', // フォントサイズ
-              color: '#333', // テキスト色
-            }}
-          >
-            {seat ? ( // 座席が使用可能な場合
-              <>
-                {student ? ( // 生徒が割り当てられている場合
-                  <div style={{ fontSize: '0.85em' }}>
-                    {/* 選択されたフィールドに基づいて生徒情報を表示 */}
-                    <div
-                      style={{
-                        display: 'flex',
-                        flexDirection: 'row',
-                        justifyContent: 'center',
-                        alignItems: 'center',
-                        gap: '8px',
-                        marginBottom: '4px',
-                      }}
-                    >
-                      {selectedFields.number && student.number ? <div>{`${student.number}: `}</div>: <div></div>}
-                      {selectedFields.name && student.name ? <div style={{ fontSize: 16, fontWeight: 'bold' }}>{`${student.name}`}</div>: <div>-</div>}
+          return (
+            <div
+              key={`${r}-${c}`}
+              className="print-seat-cell"
+              style={{
+                border: seat ? '1px solid #000' : '1px solid #bbb',
+                borderRadius: 0,
+                padding: '6px',
+                aspectRatio: '16/11',
+                minHeight: '60px',
+                display: 'flex',
+                flexDirection: 'column',
+                justifyContent: 'center',
+                alignItems: 'center',
+                backgroundColor: '#fff',
+                textAlign: 'center',
+                fontSize: '0.9em',
+                color: '#333',
+              }}
+            >
+              {seat ? (
+                <>
+                  {student ? (
+                    <div style={{ fontSize: '0.85em' }}>
+                      <div style={{ display: 'flex', flexDirection: 'row', justifyContent: 'center', alignItems: 'center', gap: '6px', marginBottom: '2px' }}>
+                        {selectedFields.number && student.number && <div>{`${student.number}:`}</div>}
+                        {selectedFields.name && student.name
+                          ? <div style={{ fontSize: 15, fontWeight: 'bold' }}>{student.name}</div>
+                          : <div>-</div>
+                        }
+                      </div>
+                      {selectedFields.kana && student.kana && <div>{student.kana}</div>}
+                      <div style={{ display: 'flex', flexDirection: 'row', justifyContent: 'flex-end', gap: '4px', color: '#555' }}>
+                        {selectedFields.info1 && student.info1 && <div>{student.info1}</div>}
+                        {selectedFields.info2 && student.info2 && <div>{student.info2}</div>}
+                        {selectedFields.info3 && student.info3 && <div>{student.info3}</div>}
+                      </div>
+                      {selectedFields.id && student.id && <div style={{ fontSize: '0.75em', color: '#666' }}>{`ID: ${student.id}`}</div>}
                     </div>
-                    {selectedFields.kana && student.kana ? <div>{`${student.kana}`}</div>: <div>-</div>}
-                    <div style={{ display: 'flex', flexDirection: 'row', justifyContent: 'end', alignItems: 'start', gap: '4px', color: '#666' }}>
-                      {selectedFields.info1 && student.info1 && <div>{`${student.info1}`}</div>}
-                      {selectedFields.info2 && student.info2 && <div>{`${student.info2}`}</div>}
-                      {selectedFields.info3 && student.info3 && <div>{`${student.info3}`}</div>}
-                    </div>
-                    {selectedFields.id && student.id && <div>{`生徒ID: ${student.id}`}</div>}
-                  </div>
-                ) : ( // 生徒が割り当てられていない場合
-                  <div style={{ color: '#888' }}>空席</div>
-                )}
-              </>
-            ) : ( // 座席が使用不可の場合
-              <div style={{ color: '#aaa' }}>使用不可</div>
-            )}
-          </div>
-        );
-      })}
+                  ) : (
+                    <div style={{ color: '#999' }}>空席</div>
+                  )}
+                </>
+              ) : (
+                <div style={{ color: '#ccc' }}>-</div>
+              )}
+            </div>
+          );
+        })}
       </div>
-      <div style={{ textAlign: 'center', marginTop: '8px', fontSize: '0.8em', color: '#666' }}>
+
+      <div style={{ textAlign: 'center', marginTop: '6px', fontSize: '0.8em', color: '#666' }}>
         後
       </div>
     </div>

--- a/src/components/Output/PrintableSeatChart.tsx
+++ b/src/components/Output/PrintableSeatChart.tsx
@@ -1,4 +1,3 @@
-// src/components/output/PrintableSeatChart.tsx
 import React from 'react';
 import type { Student } from '../../types/Student';
 import type { SeatMapData } from '../../types/Seat';
@@ -39,17 +38,20 @@ const PrintableSeatChart: React.FC<PrintableSeatChartProps> = ({
   const gridTemplateColumns = `repeat(${maxCol}, minmax(100px, 1fr))`;
 
   return (
-    <div
-      style={{
-        display: 'grid',
-        gridTemplateColumns: gridTemplateColumns, // 動的に設定された列
-        gap: '10px', // 座席間のスペース
-        border: '1px solid #ccc', // 全体の枠線
-        padding: '10px', // 内側の余白
-        backgroundColor: '#f9f9f9', // 背景色
-        overflowX: 'auto', // 横スクロールが必要な場合
-      }}
-    >
+    <div>
+      <div style={{ backgroundColor: '#424242', color: '#fff', textAlign: 'center', padding: '4px 0', borderRadius: '4px', marginBottom: '8px', fontSize: '0.85em' }}>
+        黒板（前）
+      </div>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: gridTemplateColumns,
+          gap: '8px',
+          border: '1px solid #ccc',
+          padding: '8px',
+          backgroundColor: '#f9f9f9',
+        }}
+      >
       {/* 最大行と最大列に基づいてグリッドセルを生成 */}
       {Array.from({ length: maxRow * maxCol }).map((_, index) => {
         const r = Math.floor(index / maxCol) + 1; // 現在の行番号
@@ -118,6 +120,10 @@ const PrintableSeatChart: React.FC<PrintableSeatChartProps> = ({
           </div>
         );
       })}
+      </div>
+      <div style={{ textAlign: 'center', marginTop: '8px', fontSize: '0.8em', color: '#666' }}>
+        後
+      </div>
     </div>
   );
 };

--- a/src/index.css
+++ b/src/index.css
@@ -106,3 +106,27 @@ a {
   margin-bottom: 16px;
 }
 */
+
+@media print {
+  @page {
+    size: A4 landscape;
+    margin: 10mm;
+  }
+
+  /* 画面上の全要素を非表示にし、印刷エリアだけを表示する */
+  body * {
+    visibility: hidden;
+  }
+
+  #print-area,
+  #print-area * {
+    visibility: visible;
+  }
+
+  #print-area {
+    position: fixed;
+    inset: 0;
+    width: 100%;
+    padding: 0;
+  }
+}

--- a/src/index.css
+++ b/src/index.css
@@ -123,10 +123,53 @@ a {
     visibility: visible;
   }
 
+  /* #print-area をページ全体に固定し、フレックス縦積みで子要素に高さを配分する */
   #print-area {
-    position: fixed;
-    inset: 0;
-    width: 100%;
-    padding: 0;
+    position: fixed !important;
+    inset: 0 !important;
+    width: 100% !important;
+    padding: 0 !important;
+    display: flex !important;
+    flex-direction: column !important;
+  }
+
+  /* MUI Paper: シャドウ・余白を除去してフレックス子要素として伸長させる */
+  #print-area .MuiPaper-root {
+    flex: 1 !important;
+    display: flex !important;
+    flex-direction: column !important;
+    box-shadow: none !important;
+    margin: 0 !important;
+    padding: 4mm !important;
+    background: white !important;
+  }
+
+  /* 座席チャートのラッパー Box: 残りの高さを占有する */
+  .print-chart-wrapper {
+    flex: 1 !important;
+    display: flex !important;
+    flex-direction: column !important;
+    overflow: visible !important;
+  }
+
+  /* PrintableSeatChart のルート div: 縦方向に伸長 */
+  .print-chart-root {
+    flex: 1 !important;
+  }
+
+  /* 座席グリッド: 列を均等幅に、行をグリッド高さの 1fr で均等分割する */
+  .print-seat-grid {
+    flex: 1 !important;
+    overflow: visible !important;
+    grid-template-columns: repeat(var(--seat-cols, 7), 1fr) !important;
+    grid-auto-rows: 1fr !important;
+    gap: 4px !important;
+  }
+
+  /* 座席セル: aspect-ratio・min-height を解除して行高さに追従させる */
+  .print-seat-cell {
+    aspect-ratio: unset !important;
+    min-height: unset !important;
+    box-shadow: none !important;
   }
 }


### PR DESCRIPTION
## 何を変えたか

- `jspdf` / `html2canvas` パッケージを削除し、`window.print()` + CSS `@media print` によるブラウザ標準印刷に切り替えた
- `OutputPanel.tsx`: PDF出力ボタンを印刷ボタンに変更、不要な`getOutputTableData`・詳細テーブルを削除してUIを整理
- `PrintableSeatChart.tsx`: 黒板（前）/後 ラベルを追加
- `src/index.css`: `@media print` + `@page { size: A4 landscape }` を追加。`#print-area` のみを印刷表示

## なぜ変えたか

- jsPDF は DOM を画像化してから PDF 化するため、テキストが画像になり文字がぼやける
- html2canvas によるキャプチャは日本語フォントの描画が不安定
- `window.print()` はブラウザが直接 DOM を印刷するため品質が高く、フォント・レイアウト共に正確
- バンドルサイズが約 570KB 削減（1,250KB → 681KB）

## テスト

- `npm run build` でビルドエラーなし
- 印刷時は `#print-area`（座席表）のみが表示され、操作パネル・ヘッダーは非表示